### PR TITLE
feat(uae): harvesters for DIFC, ADGM and Dubai Courts

### DIFF
--- a/scripts/uae/README.md
+++ b/scripts/uae/README.md
@@ -1,0 +1,99 @@
+# UAE court-decision harvesters
+
+Tools for building the `ae_court_decisions` corpus (DIFC, ADGM, Dubai Courts).
+
+## Sources and what each needs
+
+| Source | Format | Auth | Reachable from EU |
+|---|---|---|---|
+| DIFC Courts | HTML | none | yes |
+| ADGM Courts | PDF | none | yes |
+| Dubai Courts | HTML | none | **no — UAE IP required** |
+| MOJ / Federal Supreme Court | HTML | none | no (blocks AWS ranges too) |
+| ADJD (Abu Dhabi) | HTML | **UAE Pass** | not obtainable |
+
+DIFC and ADGM run anywhere. Dubai Courts geo-blocks non-UAE IPs, so requests go
+through a Lambda deployed in `me-central-1` (`lambda/uae_fetch.py`).
+
+## Layout
+
+```
+harvest_difc.py        DIFC judgments for one year   -> JSONL
+harvest_adgm.py        ADGM judgments (PDF)          -> JSONL
+lambda/uae_fetch.py    UAE-resident proxy: fetch | walk | texts
+index_chain.sh         chained index walk per litigation stage
+texts_pipeline.sh      fan-out full-text fetch behind the index walk
+build_dubai_jsonl.py   join index metadata + texts   -> JSONL
+sql/01_create_table.sql
+sql/02_load_difc_adgm.sql
+sql/03_load_dubai.sql
+```
+
+## Usage
+
+```bash
+# one-off, run anywhere
+python3 harvest_difc.py 2026 difc_2026.jsonl
+python3 harvest_adgm.py all adgm_all.jsonl
+
+# Dubai: needs the Lambda deployed in me-central-1 and an AWS profile for it
+export UAE_BUCKET=<harvest bucket>      # required
+export UAE_PROFILE=uae UAE_REGION=me-central-1
+./index_chain.sh                        # index walk, stage by stage
+./texts_pipeline.sh                     # full texts for the indexed rows
+python3 build_dubai_jsonl.py <index_dir> <texts_dir> ae_dubai.jsonl
+```
+
+Load with `psql -f sql/0X_....sql` after copying the JSONL to `/tmp` inside the
+Postgres container. Loads are idempotent (`ON CONFLICT DO UPDATE`).
+
+## Things that will bite you
+
+**Dubai Courts is OutSystems, not a normal site.** Pagination goes through
+`OsAjax`, which submits the whole form with three hidden fields: `__EVENTTARGET`,
+`__AJAXEVENT` and — the one that is easy to miss — **`__AJAX`**, a plain
+comma-joined click context
+(`docW,docH,originId,offTop,offLeft,scrollTop,scrollLeft,mouseX,mouseY,`). No
+token, no signature. Without `__AJAX` the server silently keeps returning page 1.
+The response is an `OsJSONUpdate({...})` payload: rows arrive JSON-escaped under
+`"outers"→"inner"`, the next state under `"hidden":{"__OSVSTATE":...}`.
+In the anchor `onclick`, quotes are escaped as `&#39;` — a regex expecting `'`
+matches nothing and pagination looks broken.
+
+**Only the litigation-stage filter works.** Case year, main type and subtype are
+accepted and ignored (`total_pages` is identical for every value), so the corpus
+cannot be partitioned by query and each stage must be walked sequentially. Results
+are not date-ordered either: one page mixes 2010-2026.
+
+**Pagination cost grows with depth.** Measured: ~3.5 s/page at page 500, ~4.8 s at
+page 900, ~7 s at page 1500 — roughly `1.7 + 0.0034 × page` seconds. Total walk
+time is therefore quadratic in page count. Cassation (1356 pages) takes ~2 h;
+first instance (9553 pages) would take ~2 days.
+
+**Go slow or the portal drops you.** At 0.15 s between pages the server started
+returning `RemoteDisconnected` after 20-50 pages. At 0.8 s it runs for the full
+Lambda budget without a single drop. `index_chain.sh` also sleeps 60 s between
+chunks.
+
+**Async Lambda invocations were unreliable here** — they started and died without
+writing anything, while CloudWatch reported zero errors and zero dropped events.
+Everything now uses synchronous invokes with `--cli-read-timeout 0`.
+
+**Resume is by saved session, not by re-walking.** Each chunk stores cookies +
+`__OSVSTATE` + the next page target in S3, so the next invocation continues with
+no fast-forward. Verify a deploy with `CodeSha256`, not `LastUpdateStatus` —
+polling status returns the previous "Successful" and you end up testing stale code.
+
+**Dates come in two languages.** The same portal serves `02 يناير 2011` and
+`28 Jan 2014`; `build_dubai_jsonl.py` handles Arabic, Levantine and English month
+names plus Arabic-Indic digits.
+
+## Legal note
+
+Dubai Courts' terms of use prohibit reproducing the service in whole or in part
+**for commercial purposes** without written permission; they say nothing about
+automated access or rate limits. UAE Copyright Law 38/2021 excludes judicial
+decisions from copyright, but that does not displace the contractual term. A
+written permission request was sent to `info@dc.gov.ae` on 2026-08-01 committing
+to attribution, no redistribution of raw texts, respecting any rate limits they
+specify, and deletion on request. Honour those commitments when using this data.

--- a/scripts/uae/build_dubai_jsonl.py
+++ b/scripts/uae/build_dubai_jsonl.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Join Dubai Courts index metadata with fetched full texts -> JSONL for ae_court_decisions.
+
+Usage: build_dubai_jsonl.py <index_dir> <texts_dir> <out.jsonl>
+
+index_dir : stage{S}_c*.json.gz  (rows: subtype/serial/case_year/decision_no/stage,
+                                  case, registered, decided, days)
+texts_dir : b*.json.gz           (items: same key fields + ok/chars/text)
+"""
+import glob
+import gzip
+import hashlib
+import json
+import os
+import re
+import sys
+
+# Gregorian month names as Dubai Courts writes them, plus the spellings that vary
+AR_MONTHS = {
+    "يناير": 1, "كانون الثاني": 1,
+    "فبراير": 2, "شباط": 2,
+    "مارس": 3, "آذار": 3,
+    "أبريل": 4, "ابريل": 4, "إبريل": 4, "نيسان": 4,
+    "مايو": 5, "أيار": 5, "ايار": 5,
+    "يونيو": 6, "يونية": 6, "حزيران": 6,
+    "يوليو": 7, "يولية": 7, "تموز": 7,
+    "أغسطس": 8, "اغسطس": 8, "آب": 8,
+    "سبتمبر": 9, "أيلول": 9, "ايلول": 9,
+    "أكتوبر": 10, "اكتوبر": 10, "تشرين الأول": 10,
+    "نوفمبر": 11, "تشرين الثاني": 11,
+    "ديسمبر": 12, "كانون الأول": 12,
+}
+# the portal also serves English month names on some pages
+EN_MONTHS = {m: i + 1 for i, m in enumerate(
+    ["jan", "feb", "mar", "apr", "may", "jun",
+     "jul", "aug", "sep", "oct", "nov", "dec"])}
+AR_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+
+STAGE = {
+    "1": ("محاكم دبي الابتدائية", "first_instance"),
+    "3": ("محكمة الاستئناف", "appeal"),
+    "5": ("محكمة التمييز", "cassation"),
+    "7": ("اللجان القضائية الخاصة", "committee"),
+}
+
+VERDICT_URL = ("https://www.dc.gov.ae/PublicServices/VerdictPreview.aspx?"
+               "OpenedPageNumber=0&Keyword=&CaseSubtypeCode=%(subtype)s&"
+               "CaseSerialNumber=%(serial)s&OpenedCaseMainType=0&CaseYear=%(case_year)s&"
+               "lang=&DecisionNumber=%(decision_no)s&OpenedLitigationStage=%(stage)s")
+
+
+def ar_date(s):
+    """'02 يناير 2011' -> '2011-01-02'. Returns None if unparseable."""
+    if not s:
+        return None
+    s = s.translate(AR_DIGITS).strip()
+    m = re.match(r"(\d{1,2})\s+(.+?)\s+(\d{4})$", s)
+    if not m:
+        return None
+    name = m.group(2).strip()
+    month = AR_MONTHS.get(name)
+    if not month:
+        month = EN_MONTHS.get(name[:3].lower())
+    if not month:
+        return None
+    return "%s-%02d-%02d" % (m.group(3), month, int(m.group(1)))
+
+
+def key(r):
+    return (str(r["subtype"]), str(r["serial"]), str(r["case_year"]),
+            str(r["decision_no"]), str(r["stage"]))
+
+
+def case_type_label(case):
+    """'455 / 2011 / 1 طعن عمالي' -> 'طعن عمالي'."""
+    if not case:
+        return None
+    m = re.match(r"\s*[\d٠-٩]+\s*/\s*[\d٠-٩]+\s*/\s*[\d٠-٩]+\s*(.*)$", case)
+    return (m.group(1).strip() or None) if m else None
+
+
+def main():
+    index_dir, texts_dir, out = sys.argv[1], sys.argv[2], sys.argv[3]
+    meta = {}
+    for f in sorted(glob.glob(os.path.join(index_dir, "stage*_c*.json.gz"))):
+        for r in json.loads(gzip.open(f).read()):
+            meta[key(r)] = r
+    sys.stderr.write("index rows: %d\n" % len(meta))
+
+    written = no_meta = no_text = bad_date = 0
+    with open(out, "w", encoding="utf-8") as fh:
+        for f in sorted(glob.glob(os.path.join(texts_dir, "b*.json.gz"))):
+            for it in json.loads(gzip.open(f).read()):
+                if not it.get("ok") or not it.get("text"):
+                    no_text += 1
+                    continue
+                k = key(it)
+                m = meta.get(k)
+                if m is None:
+                    no_meta += 1
+                    m = {}
+                decided = ar_date(m.get("decided"))
+                if m.get("decided") and not decided:
+                    bad_date += 1
+                stage = k[4]
+                court_name, level = STAGE.get(stage, ("محاكم دبي", "other"))
+                text = it["text"].replace("\x00", "")
+                rec = {
+                    "doc_id": "dubai:%s/%s/%s/%s/%s" % k,
+                    "source": "dubai_courts",
+                    "jurisdiction": "Dubai",
+                    "court_name": court_name,
+                    "court_level": level,
+                    "case_number": m.get("case"),
+                    "neutral_citation": None,
+                    "case_title": m.get("case"),
+                    "decision_date": decided,
+                    "language": "ar",
+                    "parties": None,
+                    "judges": [],
+                    "decision_type": case_type_label(m.get("case")),
+                    "full_text": text,
+                    "text_source": "html",
+                    "source_url": VERDICT_URL % {"subtype": k[0], "serial": k[1],
+                                                 "case_year": k[2], "decision_no": k[3],
+                                                 "stage": k[4]},
+                    "pdf_url": None,
+                    "content_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                    "metadata_json": {
+                        "registered_ar": m.get("registered"),
+                        "registered": ar_date(m.get("registered")),
+                        "decided_ar": m.get("decided"),
+                        "duration_days": m.get("days"),
+                        "case_subtype_code": k[0],
+                        "litigation_stage_code": stage,
+                    },
+                }
+                line = json.dumps(rec, ensure_ascii=False)
+                fh.write(line.replace("\x01", " ").replace("\x02", " ") + "\n")
+                written += 1
+    sys.stderr.write("written=%d  no_text=%d  missing_metadata=%d  unparsed_dates=%d\n"
+                     % (written, no_text, no_meta, bad_date))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/harvest_adgm.py
+++ b/scripts/uae/harvest_adgm.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Harvest ADGM Courts judgments (PDF) for a given year into JSONL.
+
+Usage: harvest_adgm.py <year> <out.jsonl>
+Text is extracted with pdftotext -layout (poppler).
+"""
+import hashlib
+import html as htmlmod
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+import requests
+
+LIST = "https://www.adgm.com/adgm-courts/judgments"
+UA = "Mozilla/5.0 (compatible; SecondLayer-research/1.0; +https://legal.org.ua)"
+S = requests.Session()
+S.headers.update({"User-Agent": UA, "Accept-Language": "en"})
+
+MONTHS = {m: i + 1 for i, m in enumerate(
+    ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"])}
+
+
+def clean(fragment):
+    if fragment is None:
+        return None
+    t = re.sub(r"(?s)<[^>]+>", " ", fragment)
+    t = htmlmod.unescape(t)
+    return re.sub(r"\s+", " ", t).strip() or None
+
+
+def cell(row, cid):
+    m = re.search(r'<adgm-table-cell id="%s">(.*?)</adgm-table-cell>' % cid, row, re.S)
+    return clean(m.group(1)) if m else None
+
+
+def get(url, tries=4, binary=False):
+    for i in range(tries):
+        try:
+            r = S.get(url, timeout=90)
+            if r.status_code == 200:
+                return r.content if binary else r.text
+            if r.status_code in (429, 500, 502, 503, 504):
+                time.sleep(5 * (i + 1))
+                continue
+            sys.stderr.write("HTTP %s %s\n" % (r.status_code, url))
+            return None
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write("ERR %s %s\n" % (e, url))
+            time.sleep(3 * (i + 1))
+    return None
+
+
+def pdf_text(blob):
+    fd, path = tempfile.mkstemp(suffix=".pdf")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(blob)
+        out = subprocess.run(["pdftotext", "-layout", "-enc", "UTF-8", path, "-"],
+                             capture_output=True, timeout=180)
+        txt = out.stdout.decode("utf-8", "replace")
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write("PDFERR %s\n" % e)
+        return None
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    txt = txt.replace("\x00", "").replace("\x01", " ").replace("\x02", " ")
+    txt = re.sub(r"[ \t]+", " ", txt)
+    txt = re.sub(r"\n\s*\n\s*\n+", "\n\n", txt)
+    return txt.strip()
+
+
+def court_of(case_number, citation):
+    src = "%s %s" % (case_number or "", citation or "")
+    if "CFI" in src:
+        return "ADGM Court of First Instance", "first_instance"
+    if "CA" in src.split():
+        return "ADGM Court of Appeal", "appeal"
+    return "ADGM Courts", "other"
+
+
+def main():
+    year = sys.argv[1]
+    out = sys.argv[2]
+    written, page, stop = 0, 1, False
+    with open(out, "w", encoding="utf-8") as fh:
+        while not stop and page <= 60:
+            listing = get("%s?psize=50&page=%d" % (LIST, page))
+            if listing is None:
+                break
+            rows = re.findall(r"<adgm-table-row>(.*?)</adgm-table-row>", listing, re.S)
+            if not rows:
+                break
+            older = 0
+            for row in rows:
+                date_s = cell(row, "date")
+                if not date_s:
+                    continue
+                m = re.match(r"(\d{1,2})\s+([A-Za-z]{3})[a-z]*\s+(\d{4})", date_s)
+                if not m:
+                    continue
+                y = m.group(3)
+                if year != "all" and y != str(year):
+                    older += 1
+                    continue
+                date = "%s-%02d-%02d" % (y, MONTHS.get(m.group(2)[:3], 1), int(m.group(1)))
+                case_number = cell(row, "caseNumber")
+                case_name = cell(row, "caseName")
+                link = re.search(r'href="([^"]+)"', row)
+                pdf_url = htmlmod.unescape(link.group(1)) if link else None
+                citation = None
+                cm = re.search(r'href="[^"]+"[^>]*>(.*?)</a>', row, re.S)
+                if cm:
+                    citation = clean(cm.group(1))
+                text = None
+                if pdf_url:
+                    blob = get(pdf_url, binary=True)
+                    if blob:
+                        text = pdf_text(blob)
+                    time.sleep(0.5)
+                if not text or len(text) < 200:
+                    sys.stderr.write("SKIP no text %s %s\n" % (case_number, pdf_url))
+                    continue
+                court_name, level = court_of(case_number, citation)
+                doc_id = "adgm:" + re.sub(r"[^A-Za-z0-9_-]+", "-",
+                                          (citation or "%s-%s" % (case_number, date))).strip("-")
+                rec = {
+                    "doc_id": doc_id,
+                    "source": "adgm",
+                    "jurisdiction": "ADGM",
+                    "court_name": court_name,
+                    "court_level": level,
+                    "case_number": case_number,
+                    "neutral_citation": citation,
+                    "case_title": case_name,
+                    "decision_date": date,
+                    "language": "en",
+                    "parties": case_name,
+                    "judges": [],
+                    "decision_type": "Judgment",
+                    "full_text": text,
+                    "text_source": "pdf",
+                    "source_url": LIST,
+                    "pdf_url": pdf_url,
+                    "content_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                    "metadata_json": {"listing_date": date_s, "summary": cell(row, "summary")},
+                }
+                fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                written += 1
+            fh.flush()
+            sys.stderr.write("page %d: %d rows, %d off-year, written %d\n"
+                             % (page, len(rows), older, written))
+            if year != "all" and older > len(rows) * 0.8:
+                stop = True
+            page += 1
+            time.sleep(0.8)
+    sys.stderr.write("DONE year=%s written=%d\n" % (year, written))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/harvest_difc.py
+++ b/scripts/uae/harvest_difc.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Harvest DIFC Courts judgments & orders for a given year into JSONL.
+
+Usage: harvest_difc.py <year> <out.jsonl>
+Public source, no auth. One request at a time, polite delay.
+"""
+import hashlib
+import html as htmlmod
+import json
+import re
+import sys
+import time
+
+import requests
+
+BASE = "https://www.difccourts.ae"
+LIST = BASE + "/rules-decisions/judgments-orders"
+UA = "Mozilla/5.0 (compatible; SecondLayer-research/1.0; +https://legal.org.ua)"
+
+S = requests.Session()
+S.headers.update({"User-Agent": UA, "Accept-Language": "en"})
+
+ROW = re.compile(
+    r'<div class="each_result content_set">\s*<h4><a href="([^"]+)">(.*?)</a></h4>\s*'
+    r'<p class="label_small">\s*(.*?)\s*</p>',
+    re.S,
+)
+MONTHS = {m: i + 1 for i, m in enumerate(
+    ["January", "February", "March", "April", "May", "June",
+     "July", "August", "September", "October", "November", "December"])}
+
+COURT_LEVEL = {
+    "court of first instance": "first_instance",
+    "court of appeal": "appeal",
+    "arbitration": "arbitration",
+    "small claims tribunal": "small_claims",
+    "technology and construction division": "first_instance",
+    "digital economy court": "first_instance",
+}
+
+
+def get(url, tries=4):
+    for i in range(tries):
+        try:
+            r = S.get(url, timeout=60)
+            if r.status_code == 200:
+                return r.text
+            if r.status_code in (429, 500, 502, 503, 504):
+                time.sleep(5 * (i + 1))
+                continue
+            sys.stderr.write("HTTP %s %s\n" % (r.status_code, url))
+            return None
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write("ERR %s %s\n" % (e, url))
+            time.sleep(3 * (i + 1))
+    return None
+
+
+def strip_tags(fragment):
+    f = re.sub(r"(?is)<(script|style)[^>]*>.*?</\1>", " ", fragment)
+    f = re.sub(r"(?i)<br\s*/?>", "\n", f)
+    f = re.sub(r"(?i)</(p|div|tr|li|h[1-6])>", "\n\n", f)
+    f = re.sub(r"(?i)</t[dh]>", "\t", f)
+    f = re.sub(r"(?s)<[^>]+>", "", f)
+    f = htmlmod.unescape(f)
+    f = f.replace(" ", " ").replace("\x00", "")
+    f = re.sub(r"[ \t]+", " ", f)
+    f = re.sub(r"\n\s*\n\s*\n+", "\n\n", f)
+    return f.strip()
+
+
+def extract_body(page):
+    """Return the judgment text container, honouring nested <div>s."""
+    anchor = page.find('class="content_set_detail')
+    if anchor == -1:
+        anchor = 0
+    start = page.find('<div class="content_desc"', anchor)
+    if start == -1:
+        return None
+    i = page.find(">", start) + 1
+    depth = 1
+    pos = i
+    for m in re.finditer(r"<(/?)div\b", page[i:]):
+        depth += 1 if not m.group(1) else -1
+        if depth == 0:
+            pos = i + m.start()
+            break
+    else:
+        pos = len(page)
+    return page[i:pos]
+
+
+def parse_label(label):
+    """'July 14, 2026  Court of Appeal - Judgments' -> (date, court, type)."""
+    label = re.sub(r"\s+", " ", strip_tags(label)).strip()
+    m = re.match(r"([A-Z][a-z]+) (\d{1,2}), (\d{4})\s*(.*)$", label)
+    if not m:
+        return None, None, None
+    d = "%04d-%02d-%02d" % (int(m.group(3)), MONTHS.get(m.group(1), 1), int(m.group(2)))
+    rest = m.group(4).strip(" -")
+    if " - " in rest:
+        court, dtype = rest.split(" - ", 1)
+    else:
+        court, dtype = rest, None
+    return d, court.strip() or None, (dtype or "").strip() or None
+
+
+def parse_item(url, title_html, label_html):
+    page = get(url)
+    if page is None:
+        return None
+    body = extract_body(page)
+    if body is None:
+        return None
+    text = strip_tags(body)
+    if len(text) < 200:
+        return None
+    title = strip_tags(title_html)
+    date, court, dtype = parse_label(label_html)
+
+    cite = None
+    mc = re.search(r"\[(20\d\d)\]\s*DIFC\s*([A-Z]{2,4})\s*(\d+)", title)
+    if mc:
+        cite = "[%s] DIFC %s %s" % (mc.group(1), mc.group(2), mc.group(3))
+    case_no = None
+    mn = re.search(r"Claim\s*No[.:]?\s*([A-Z]{2,5}[\s-]*\d+\s*/\s*\d{4})", text)
+    if mn:
+        case_no = re.sub(r"\s+", " ", mn.group(1)).strip()
+    else:
+        mt = re.match(r"([A-Z]{2,5}\s*\d+\s*/\s*\d{4})", title)
+        if mt:
+            case_no = re.sub(r"\s+", " ", mt.group(1)).strip()
+
+    judges = re.findall(
+        r"(?:H\.E\.\s+)?(?:DEPUTY\s+)?(?:CHIEF\s+)?JUSTICE\s+([A-Z][A-Z .'-]{3,60})", text)
+    judges = sorted({re.sub(r"\s+", " ", j).strip(" .,") for j in judges})[:12]
+
+    slug = url.rstrip("/").rsplit("/", 1)[-1]
+    return {
+        "doc_id": "difc:" + slug,
+        "source": "difc",
+        "jurisdiction": "DIFC",
+        "court_name": court,
+        "court_level": COURT_LEVEL.get((court or "").lower(), "other"),
+        "case_number": case_no,
+        "neutral_citation": cite,
+        "case_title": title,
+        "decision_date": date,
+        "language": "en",
+        "parties": title,
+        "judges": judges,
+        "decision_type": dtype,
+        "full_text": text,
+        "text_source": "html",
+        "source_url": url,
+        "pdf_url": None,
+        "content_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "metadata_json": {"listing_label": re.sub(r"\s+", " ", strip_tags(label_html)),
+                          "section": url.split("/")[-2] if "/" in url else None},
+    }
+
+
+def main():
+    year = sys.argv[1]
+    out = sys.argv[2]
+    seen, written, page = set(), 0, 1
+    with open(out, "w", encoding="utf-8") as fh:
+        while True:
+            url = "%s?year=%s&ccm_paging_p=%d&ccm_order_by=ak_date&ccm_order_by_direction=desc" % (
+                LIST, year, page)
+            listing = get(url)
+            if listing is None:
+                break
+            rows = ROW.findall(listing)
+            if not rows:
+                break
+            fresh = 0
+            for item_url, title_html, label_html in rows:
+                if not item_url.startswith("http"):
+                    item_url = BASE + item_url
+                if item_url in seen:
+                    continue
+                seen.add(item_url)
+                fresh += 1
+                rec = parse_item(item_url, title_html, label_html)
+                if rec is None:
+                    sys.stderr.write("SKIP %s\n" % item_url)
+                    continue
+                if rec["decision_date"] and not rec["decision_date"].startswith(str(year)):
+                    continue
+                line = json.dumps(rec, ensure_ascii=False)
+                line = line.replace("\x01", " ").replace("\x02", " ")
+                fh.write(line + "\n")
+                written += 1
+                time.sleep(0.4)
+            sys.stderr.write("page %d: %d rows, %d new, total written %d\n"
+                             % (page, len(rows), fresh, written))
+            fh.flush()
+            if fresh == 0:
+                break
+            page += 1
+            time.sleep(0.6)
+    sys.stderr.write("DONE year=%s written=%d unique_urls=%d\n" % (year, written, len(seen)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/index_chain.sh
+++ b/scripts/uae/index_chain.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Chained index walker: one background chain per litigation stage.
+# Each Lambda invocation walks CHUNK pages, writes its rows to S3 and saves the
+# OutSystems session state so the next invocation resumes with zero fast-forward.
+set -u
+SD="${UAE_WORK_DIR:-$(cd "$(dirname "$0")" && pwd)/work}"
+mkdir -p "$SD"
+B="${UAE_BUCKET:?set UAE_BUCKET}"
+AWS="aws --profile ${UAE_PROFILE:-uae} --region ${UAE_REGION:-me-central-1}"
+CHUNK=5000
+LOG=$SD/index_chain.log
+: > "$LOG"
+say() { echo "$(date -u +%H:%M:%SZ) [$1] ${*:2}" >> "$LOG"; }
+
+chain() {
+    local S=$1 DELAY=$2 n=0 resume=""
+    # pick up where a previous run left off: newest chunk in S3 + its saved state
+    local last=$($AWS s3api list-objects-v2 --bucket "$B" --prefix "index/stage${S}_c" \
+                 --query "Contents[].Key" --output text 2>/dev/null | tr '\t' '\n' \
+                 | grep -oE 'c[0-9]+' | sort | tail -1)
+    if [ -n "$last" ]; then
+        n=$((10#${last#c}))
+        local sk_prev=$(printf "state/stage%s_c%02d.json.gz" "$S" "$n")
+        if $AWS s3 ls "s3://$B/$sk_prev" >/dev/null 2>&1; then
+            resume="$sk_prev"
+            say "$S" "resuming after chunk $n (state $sk_prev)"
+        else
+            say "$S" "chunk $n exists but no state - restarting stage from scratch"
+            n=0
+        fi
+    fi
+    while [ $n -lt 30 ]; do
+        n=$((n+1))
+        local ck=$(printf "index/stage%s_c%02d.json.gz" "$S" "$n")
+        local sk=$(printf "state/stage%s_c%02d.json.gz" "$S" "$n")
+        local pay="{\"mode\":\"walk\",\"stage\":\"$S\",\"pages\":$CHUNK,\"delay\":$DELAY,\"timeout\":45,\"s3_key\":\"$ck\",\"save_state_key\":\"$sk\""
+        [ -n "$resume" ] && pay="$pay,\"resume_state_key\":\"$resume\""
+        pay="$pay}"
+        say "$S" "chunk $n running synchronously (resume=${resume:-none})"
+        local out="$SD/resp_stage${S}_c${n}.json"
+        rm -f "$out"
+        # sync invoke: async events were silently dying without writing anything
+        $AWS lambda invoke --function-name uae-fetch \
+             --cli-read-timeout 0 --cli-connect-timeout 60 \
+             --cli-binary-format raw-in-base64-out --payload "$pay" "$out" >/dev/null 2>&1
+        local summary=$(python3 -c "
+import json,sys
+try:
+    d=json.load(open('$out'))
+except Exception as e:
+    print('NO RESPONSE (%s)' % e); raise SystemExit
+print('ok=%s rows=%s last_page=%s stopped_early=%s err=%s%s' % (
+    d.get('ok'), d.get('row_count'), d.get('last_page'), d.get('stopped_early'),
+    d.get('err'), d.get('errorMessage','')))
+" 2>&1)
+        say "$S" "chunk $n returned: $summary"
+        if ! $AWS s3 ls "s3://$B/$ck" >/dev/null 2>&1; then
+            say "$S" "chunk $n wrote no object - aborting chain"; return 1
+        fi
+        local sz=$($AWS s3 ls "s3://$B/$ck" | awk '{print $3}')
+        say "$S" "chunk $n stored (${sz} bytes)"
+        sleep 60   # COOLDOWN between chunks, be gentle with the portal
+        if $AWS s3 ls "s3://$B/$sk" >/dev/null 2>&1; then
+            resume="$sk"
+        else
+            say "$S" "no further state -> stage $S COMPLETE after $n chunks"; return 0
+        fi
+    done
+    say "$S" "hit 12-chunk cap"
+}
+
+# Sequential: one stage at a time, no self-competition for the portal.
+# Smallest first, so a whole stage completes early and depth effects show up clean.
+say "ALL" "waiting up to 12 min for in-flight chunks to land"
+for i in $(seq 1 24); do
+    N=$($AWS s3api list-objects-v2 --bucket "$B" --prefix "index/stage" \
+        --query "Contents[].Key" --output text 2>/dev/null | tr '\t' '\n' | grep -c "_c02" || true)
+    [ "${N:-0}" -ge 3 ] && { say "ALL" "in-flight chunks landed ($N)"; break; }
+    sleep 30
+done
+
+for spec in "5 0.8" "3 0.8" "1 0.8"; do
+    set -- $spec
+    say "ALL" "=== starting stage $1 ==="
+    chain "$1" "$2"
+    say "ALL" "=== stage $1 returned $? ==="
+done
+say "ALL" "index chains finished"

--- a/scripts/uae/lambda/uae_fetch.py
+++ b/scripts/uae/lambda/uae_fetch.py
@@ -1,0 +1,325 @@
+"""UAE harvest proxy (me-central-1).
+
+Modes:
+  fetch : plain GET of a URL              -> body_b64
+  walk  : Dubai Courts search + page walk -> rows[]
+
+`walk` replicates the OutSystems OsAjax postback: the browser sets hidden
+fields __EVENTTARGET (unique control name) and __AJAX (comma-joined click
+context: docW,docH,originId,offTop,offLeft,scrollTop,scrollLeft,mouseX,mouseY,)
+then submits the whole form. The partial response carries the next
+__OSVSTATE in {"hidden":{"__OSVSTATE":"..."}} and new rows inside
+{"outers":{...:{"inner":"<escaped html>"}}}.
+"""
+import base64, gzip, io, json, os, re, time, urllib.parse, urllib.request, http.cookiejar
+import boto3
+
+BUCKET = os.environ['HARVEST_BUCKET']
+
+
+def _s3_put(key, obj):
+    body = gzip.compress(json.dumps(obj, ensure_ascii=False).encode('utf-8'), 6)
+    boto3.client('s3').put_object(Bucket=BUCKET, Key=key, Body=body,
+                                  ContentType='application/json', ContentEncoding='gzip')
+    return {'bucket': BUCKET, 'key': key, 'bytes': len(body)}
+
+UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36")
+P = "DCWeb_Template_wt29$block$wtUT_MainContent$wt4$"
+LIST_URL = "https://www.dc.gov.ae/PublicServices/LatestVerdicts.aspx"
+
+Q = r"(?:'|&#39;|&#039;|\\\\')"
+ANCHOR = re.compile(
+    r"OsAjax\(arguments\[0\]\s*\|\|\s*window\.event,\s*" + Q + r"([^'&\\]+)" + Q +
+    r"\s*,\s*" + Q + r"([^'&\\]+)" + Q +
+    r".{0,500}?>\s*(?:<[^>]+>\s*)*([^<]{1,12}?)\s*<", re.S)
+PREVIEW = re.compile(
+    r"VerdictPreview\.aspx\?[^\"']*?CaseSubtypeCode=(\d+)[^\"']*?CaseSerialNumber=(\d+)"
+    r"[^\"']*?CaseYear=(\d+)[^\"']*?DecisionNumber=(\d+)[^\"']*?OpenedLitigationStage=(\d+)")
+ROW = re.compile(r"<tr[^>]*>(.*?)</tr>", re.S)
+CELL = re.compile(r"<td[^>]*>(.*?)</td>", re.S)
+
+
+def _read(r):
+    raw = r.read()
+    if r.headers.get("Content-Encoding") == "gzip":
+        raw = gzip.GzipFile(fileobj=io.BytesIO(raw)).read()
+    return raw.decode("utf-8", "replace")
+
+
+def _hidden(doc):
+    out = {}
+    for m in re.finditer(r'<input[^>]*type="hidden"[^>]*>', doc, re.I):
+        n = re.search(r'name="([^"]+)"', m.group(0))
+        v = re.search(r'value="([^"]*)"', m.group(0))
+        if n:
+            out[n.group(1)] = v.group(1) if v else ""
+    m = re.search(r'"hidden"\s*:\s*\{\s*"__OSVSTATE"\s*:\s*"((?:[^"\\]|\\.)*)"', doc)
+    if m:
+        out["__OSVSTATE"] = json.loads('"%s"' % m.group(1))
+    return out
+
+
+def _unescape_partial(doc):
+    frags = []
+    for m in re.finditer(r'"inner"\s*:\s*"((?:[^"\\]|\\.)*)"', doc):
+        try:
+            frags.append(json.loads('"%s"' % m.group(1)))
+        except ValueError:
+            pass
+    return "\n".join(frags)
+
+
+def _rows(doc):
+    out = []
+    for rm in ROW.finditer(doc):
+        pm = PREVIEW.search(rm.group(1))
+        if not pm:
+            continue
+        cells = [re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", c)).strip()
+                 for c in CELL.findall(rm.group(1))]
+        cells = [c for c in cells if c]
+        out.append({"subtype": pm.group(1), "serial": pm.group(2), "case_year": pm.group(3),
+                    "decision_no": pm.group(4), "stage": pm.group(5),
+                    "case": cells[0] if cells else None,
+                    "registered": cells[1] if len(cells) > 1 else None,
+                    "decided": cells[2] if len(cells) > 2 else None,
+                    "days": cells[3] if len(cells) > 3 else None})
+    return out
+
+
+
+VERDICT_URL = ("https://www.dc.gov.ae/PublicServices/VerdictPreview.aspx?"
+               "OpenedPageNumber=0&Keyword=&CaseSubtypeCode=%(subtype)s&"
+               "CaseSerialNumber=%(serial)s&OpenedCaseMainType=0&CaseYear=%(case_year)s&"
+               "lang=&DecisionNumber=%(decision_no)s&OpenedLitigationStage=%(stage)s")
+
+
+def _text(doc):
+    t = re.sub(r"(?is)<(script|style)[^>]*>.*?</\1>", " ", doc)
+    m = re.search(r'(?is)<div[^>]*class="[^"]*content[^"]*"[^>]*>(.*)</div>', t)
+    if m and len(m.group(1)) > 500:
+        t = m.group(1)
+    t = re.sub(r"(?i)<br\s*/?>", "\n", t)
+    t = re.sub(r"(?i)</(p|div|tr|li|h[1-6])>", "\n", t)
+    t = re.sub(r"(?s)<[^>]+>", " ", t)
+    for a, b in [("&nbsp;", " "), ("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"),
+                 ("&quot;", '"'), ("&#39;", "'")]:
+        t = t.replace(a, b)
+    t = t.replace("\x00", "").replace("\x01", " ").replace("\x02", " ")
+    t = re.sub(r"[ \t]+", " ", t)
+    t = re.sub(r"\n\s*\n+", "\n\n", t)
+    return t.strip()
+
+
+
+
+def _dump_cookies(cj):
+    return [{"name": c.name, "value": c.value, "domain": c.domain, "path": c.path}
+            for c in cj]
+
+
+def _load_cookies(cj, items):
+    import http.cookiejar as cjm
+    for it in items:
+        cj.set_cookie(cjm.Cookie(0, it["name"], it["value"], None, False,
+                                 it["domain"], True, it["domain"].startswith("."),
+                                 it["path"], True, False, None, True, None, None, {}))
+
+
+def _s3_get(key):
+    body = boto3.client("s3").get_object(Bucket=BUCKET, Key=key)["Body"].read()
+    return json.loads(gzip.decompress(body))
+
+
+def _num_targets(view):
+    out = {}
+    for oid, uniq, label in ANCHOR.findall(view):
+        s = label.strip()
+        if s.isdigit():
+            out[int(s)] = (oid, uniq)
+    return out
+
+
+def lambda_handler(event, context):
+    mode = event.get("mode", "fetch")
+    timeout = event.get("timeout", 45)
+    cj = http.cookiejar.CookieJar()
+    op = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+    op.addheaders = [("User-Agent", UA), ("Accept", "text/html,*/*;q=0.8"),
+                     ("Accept-Language", "ar,en;q=0.8")]
+
+    if mode == "fetch":
+        try:
+            with op.open(event["url"], timeout=timeout) as r:
+                body = _read(r)
+            return {"ok": True, "len": len(body),
+                    "body_b64": base64.b64encode(
+                        body.encode("utf-8")[: event.get("max_bytes", 900000)]).decode()}
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "err": "%s: %s" % (type(e).__name__, e)}
+
+    if mode == "texts":
+        out = []
+        for it in event.get("items", []):
+            try:
+                with op.open(VERDICT_URL % it, timeout=timeout) as r:
+                    txt = _text(_read(r))
+                out.append(dict(it, ok=True, chars=len(txt), text=txt))
+                time.sleep(float(event.get("delay", 0.25)))
+            except Exception as e:  # noqa: BLE001
+                out.append(dict(it, ok=False, err="%s: %s" % (type(e).__name__, e)))
+        if event.get("s3_key"):
+            return {"ok": True, "count": len(out), "s3": _s3_put(event["s3_key"], out)}
+        return {"ok": True, "count": len(out), "items": out}
+
+    stage = str(event.get("stage", "5"))
+    pages = int(event.get("pages", 5))
+    filters = {P + "wtUT_LitigationStageInput": stage,
+               P + "wtUT_CaseMainTypeSearch": str(event.get("case_main_type", "__ossli_0")),
+               P + "wtUT_CaseSubtypeSearch": str(event.get("case_subtype", "__ossli_0")),
+               P + "wtUT_CaseYearSearch": str(event.get("case_year", "__ossli_0")),
+               P + "wtUT_CaseSerialNumberInput": str(event.get("case_serial", "")),
+               P + "wtUT_KeywordInput": str(event.get("keyword", "__ossli_0"))}
+
+    def post(fields):
+        data = urllib.parse.urlencode(fields, encoding="utf-8").encode()
+        req = urllib.request.Request(LIST_URL, data=data, headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Referer": LIST_URL, "Origin": "https://www.dc.gov.ae"})
+        with op.open(req, timeout=timeout) as r:
+            return _read(r)
+
+    resumed_at = None
+    try:
+        if event.get("resume_state_key"):
+            st = _s3_get(event["resume_state_key"])
+            _load_cookies(cj, st["cookies"])
+            resumed_at = st["page"]
+            fields = dict(filters)
+            fields["__OSVSTATE"] = st["osvstate"]
+            fields["__EVENTTARGET"] = st["next_target"][1]
+            fields["__EVENTARGUMENT"] = ""
+            fields["__AJAX"] = "1440,3200,%s,2400,300,0,0,700,2450," % st["next_target"][0]
+            raw = post(fields)
+            inner = _unescape_partial(raw)
+            view = (inner + "\n" + raw) if inner else raw
+        else:
+            with op.open(LIST_URL, timeout=timeout) as r:
+                doc = _read(r)
+            f = _hidden(doc)
+            f.update(filters)
+            f[P + "wtUT_SearchButton"] = "بحث"
+            view = post(f)
+    except Exception as e:  # noqa: BLE001
+        return {"ok": False, "phase": "search/resume",
+                "err": "%s: %s" % (type(e).__name__, e)}
+
+    total = None
+    i = view.find("wtcntTotalNumberOfPages")
+    if i > 0:
+        j = view.find(">", i)
+        seg = re.sub(r"<[^>]+>", " ", view[j:j + 800])
+        m = re.search(r"\d[\d,]*", seg)
+        if m:
+            total = int(m.group(0).replace(",", ""))
+
+    rows, seen, cur, visited = [], set(), (resumed_at + 1) if resumed_at else 1, []
+    def _left():
+        try:
+            return context.get_remaining_time_in_millis() / 1000.0
+        except Exception:  # noqa: BLE001
+            return 9999
+
+    start_page = int(event.get("start_page", 1))
+    ff_delay = float(event.get("ff_delay", 0.05))
+    ff_hops = 0
+    while cur < start_page:
+        if _left() < 150:
+            break
+        tg = _num_targets(view)
+        cand = [n for n in tg if cur < n <= start_page]
+        if not cand:
+            break
+        n = max(cand)
+        fields = dict(filters)
+        fields["__OSVSTATE"] = _hidden(view).get("__OSVSTATE", "")
+        fields["__EVENTTARGET"] = tg[n][1]
+        fields["__EVENTARGUMENT"] = ""
+        fields["__AJAX"] = "1440,3200,%s,2400,300,0,0,700,2450," % tg[n][0]
+        try:
+            raw = post(fields)
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "phase": "ff->%d" % n, "reached": cur,
+                    "err": "%s: %s" % (type(e).__name__, e)}
+        inner = _unescape_partial(raw)
+        view = (inner + "\n" + raw) if inner else raw
+        cur = n
+        ff_hops += 1
+        time.sleep(ff_delay)
+
+    stopped_early = False
+    disconnected = None
+    for _ in range(pages):
+        if _left() < 120:
+            stopped_early = True
+            break
+        for rec in _rows(view):
+            k = (rec["subtype"], rec["serial"], rec["case_year"], rec["decision_no"])
+            if k not in seen:
+                seen.add(k)
+                rows.append(rec)
+        visited.append(cur)
+        nxt = str(cur + 1)
+        target = None
+        for oid, uniq, label in ANCHOR.findall(view):
+            if label.strip() == nxt:
+                target = (oid, uniq)
+                break
+        if not target:
+            break
+        st = _hidden(view)
+        fields = dict(filters)
+        fields["__OSVSTATE"] = st.get("__OSVSTATE", "")
+        fields["__EVENTTARGET"] = target[1]
+        fields["__EVENTARGUMENT"] = ""
+        fields["__AJAX"] = "1440,3200,%s,2400,300,0,0,700,2450," % target[0]
+        raw = None
+        last_err = None
+        for attempt in range(4):
+            try:
+                raw = post(fields)
+                break
+            except Exception as e:  # noqa: BLE001
+                last_err = "%s: %s" % (type(e).__name__, e)
+                if _left() < 150:
+                    break
+                time.sleep(5 * (attempt + 1) ** 2)
+        if raw is None:
+            # keep whatever we already have: write rows + state, report the drop
+            disconnected = last_err
+            break
+        time.sleep(float(event.get('delay', 0.3)))
+        inner = _unescape_partial(raw)
+        view = (inner + "\n" + raw) if inner else raw
+        cur += 1
+
+    if event.get("save_state_key"):
+        tg = _num_targets(view)
+        nxt = tg.get(cur + 1)
+        if nxt:
+            _s3_put(event["save_state_key"],
+                    {"cookies": _dump_cookies(cj), "osvstate": _hidden(view).get("__OSVSTATE", ""),
+                     "page": cur, "next_target": list(nxt), "stage": stage})
+    res = {"ok": True, "stage_filter": stage, "total_pages": total,
+           "pages_visited": [visited[0], visited[-1]] if visited else [],
+           "page_count": len(visited), "row_count": len(rows),
+           "start_page": start_page, "ff_hops": ff_hops, "last_page": cur,
+           "resumed_at": resumed_at, "stopped_early": stopped_early,
+           "disconnected": disconnected}
+    if event.get("s3_key"):
+        res["s3"] = _s3_put(event["s3_key"], rows)
+        return res
+    res["rows_gz"] = base64.b64encode(gzip.compress(
+        json.dumps(rows, ensure_ascii=False).encode("utf-8"), 6)).decode()
+    return res

--- a/scripts/uae/sql/01_create_table.sql
+++ b/scripts/uae/sql/01_create_table.sql
@@ -1,0 +1,40 @@
+-- UAE court decisions corpus
+-- Sources: DIFC Courts, ADGM Courts (public, EN), later Dubai Courts / MOJ FSC (AR, via UAE proxy)
+CREATE TABLE IF NOT EXISTS ae_court_decisions (
+    doc_id            text PRIMARY KEY,          -- "<source>:<native id>", e.g. difc:2026-DIFC-CA-007
+    source            text NOT NULL,             -- difc | adgm | dubai_courts | moj_fsc | adjd
+    jurisdiction      text,                      -- DIFC | ADGM | Dubai | Abu Dhabi | Federal
+    court_name        text,
+    court_level       text,                      -- first_instance | appeal | cassation | arbitration | other
+    case_number       text,
+    neutral_citation  text,
+    case_title        text,
+    decision_date     date,
+    language          text,                      -- en | ar
+    parties           text,
+    judges            text[],
+    decision_type     text,
+    full_text         text,
+    text_source       text,                      -- html | pdf
+    source_url        text,
+    pdf_url           text,
+    content_sha256    text,
+    metadata_json     jsonb,
+    imported_at       timestamptz DEFAULT now(),
+    updated_at        timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ae_source          ON ae_court_decisions (source);
+CREATE INDEX IF NOT EXISTS idx_ae_date            ON ae_court_decisions (decision_date DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_source_date     ON ae_court_decisions (source, decision_date DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_court_level     ON ae_court_decisions (court_level);
+CREATE INDEX IF NOT EXISTS idx_ae_case_number_trgm ON ae_court_decisions USING gin (case_number gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_ae_metadata_jsonb  ON ae_court_decisions USING gin (metadata_json jsonb_path_ops);
+CREATE INDEX IF NOT EXISTS idx_ae_fts_en ON ae_court_decisions
+    USING gin (to_tsvector('english', COALESCE(case_title,'') || ' ' || COALESCE(full_text,'')))
+    WHERE language = 'en' AND full_text IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_ae_fts_ar ON ae_court_decisions
+    USING gin (to_tsvector('arabic', COALESCE(case_title,'') || ' ' || COALESCE(full_text,'')))
+    WHERE language = 'ar' AND full_text IS NOT NULL;
+
+COMMENT ON TABLE ae_court_decisions IS 'UAE court decisions (DIFC/ADGM public; Dubai Courts + Federal Supreme Court pending UAE-IP access)';

--- a/scripts/uae/sql/02_load_difc_adgm.sql
+++ b/scripts/uae/sql/02_load_difc_adgm.sql
@@ -1,0 +1,47 @@
+\set ON_ERROR_STOP on
+CREATE TEMP TABLE ae_stage(j jsonb);
+\copy ae_stage(j) FROM '/tmp/ae_all_full.jsonl' WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+SELECT count(*) AS staged, count(DISTINCT j->>'doc_id') AS distinct_ids FROM ae_stage;
+
+INSERT INTO ae_court_decisions (
+    doc_id, source, jurisdiction, court_name, court_level, case_number, neutral_citation,
+    case_title, decision_date, language, parties, judges, decision_type, full_text,
+    text_source, source_url, pdf_url, content_sha256, metadata_json)
+SELECT DISTINCT ON (j->>'doc_id')
+    j->>'doc_id', j->>'source', j->>'jurisdiction', j->>'court_name', j->>'court_level',
+    j->>'case_number', j->>'neutral_citation', j->>'case_title',
+    NULLIF(j->>'decision_date','')::date, j->>'language', j->>'parties',
+    CASE WHEN jsonb_typeof(j->'judges') = 'array'
+         THEN ARRAY(SELECT jsonb_array_elements_text(j->'judges')) END,
+    j->>'decision_type', j->>'full_text', j->>'text_source', j->>'source_url',
+    j->>'pdf_url', j->>'content_sha256', j->'metadata_json'
+FROM ae_stage
+ORDER BY j->>'doc_id', length(j->>'full_text') DESC NULLS LAST
+ON CONFLICT (doc_id) DO UPDATE SET
+    full_text = EXCLUDED.full_text, case_title = EXCLUDED.case_title,
+    decision_date = EXCLUDED.decision_date, case_number = EXCLUDED.case_number,
+    neutral_citation = EXCLUDED.neutral_citation, judges = EXCLUDED.judges,
+    decision_type = EXCLUDED.decision_type, content_sha256 = EXCLUDED.content_sha256,
+    metadata_json = EXCLUDED.metadata_json, updated_at = now();
+
+\echo '=== BY YEAR ==='
+SELECT extract(year FROM decision_date)::int AS year,
+       count(*) FILTER (WHERE source = 'difc') AS difc,
+       count(*) FILTER (WHERE source = 'adgm') AS adgm,
+       count(*) AS total,
+       pg_size_pretty(sum(length(full_text))::bigint) AS text,
+       round(avg(length(full_text))) AS avg_chars
+FROM ae_court_decisions GROUP BY 1 ORDER BY 1;
+
+\echo '=== BY COURT LEVEL ==='
+SELECT source, court_level, count(*) FROM ae_court_decisions GROUP BY 1,2 ORDER BY 1,3 DESC;
+
+\echo '=== TOTALS / QUALITY ==='
+SELECT count(*) AS rows,
+       count(DISTINCT content_sha256) AS distinct_texts,
+       count(*) FILTER (WHERE full_text IS NULL OR length(full_text) < 500) AS thin,
+       count(*) FILTER (WHERE decision_date IS NULL) AS no_date,
+       count(*) FILTER (WHERE case_number IS NULL) AS no_case_no,
+       min(decision_date) AS first, max(decision_date) AS last,
+       pg_size_pretty(pg_total_relation_size('ae_court_decisions')) AS table_size
+FROM ae_court_decisions;

--- a/scripts/uae/sql/03_load_dubai.sql
+++ b/scripts/uae/sql/03_load_dubai.sql
@@ -1,0 +1,50 @@
+\set ON_ERROR_STOP on
+CREATE TEMP TABLE ae_stage_dubai(j jsonb);
+\copy ae_stage_dubai(j) FROM '/tmp/ae_dubai.jsonl' WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+SELECT count(*) AS staged, count(DISTINCT j->>'doc_id') AS distinct_ids FROM ae_stage_dubai;
+
+INSERT INTO ae_court_decisions (
+    doc_id, source, jurisdiction, court_name, court_level, case_number, neutral_citation,
+    case_title, decision_date, language, parties, judges, decision_type, full_text,
+    text_source, source_url, pdf_url, content_sha256, metadata_json)
+SELECT DISTINCT ON (j->>'doc_id')
+    j->>'doc_id', j->>'source', j->>'jurisdiction', j->>'court_name', j->>'court_level',
+    j->>'case_number', j->>'neutral_citation', j->>'case_title',
+    NULLIF(j->>'decision_date','')::date, j->>'language', j->>'parties',
+    CASE WHEN jsonb_typeof(j->'judges') = 'array'
+         THEN ARRAY(SELECT jsonb_array_elements_text(j->'judges')) END,
+    j->>'decision_type', j->>'full_text', j->>'text_source', j->>'source_url',
+    j->>'pdf_url', j->>'content_sha256', j->'metadata_json'
+FROM ae_stage_dubai
+ORDER BY j->>'doc_id', length(j->>'full_text') DESC NULLS LAST
+ON CONFLICT (doc_id) DO UPDATE SET
+    full_text = EXCLUDED.full_text, case_title = EXCLUDED.case_title,
+    decision_date = EXCLUDED.decision_date, case_number = EXCLUDED.case_number,
+    decision_type = EXCLUDED.decision_type, content_sha256 = EXCLUDED.content_sha256,
+    metadata_json = EXCLUDED.metadata_json, updated_at = now();
+
+\echo '=== dubai_courts by court level ==='
+SELECT court_level, count(*) AS docs,
+       min(decision_date) AS first, max(decision_date) AS last,
+       pg_size_pretty(sum(length(full_text))::bigint) AS text,
+       round(avg(length(full_text))) AS avg_chars
+FROM ae_court_decisions WHERE source = 'dubai_courts'
+GROUP BY 1 ORDER BY 2 DESC;
+
+\echo '=== quality ==='
+SELECT count(*) AS rows,
+       count(*) FILTER (WHERE decision_date IS NULL) AS no_date,
+       count(*) FILTER (WHERE full_text IS NULL OR length(full_text) < 500) AS thin,
+       count(DISTINCT content_sha256) AS distinct_texts,
+       count(*) FILTER (WHERE full_text !~ '[؀-ۿ]') AS no_arabic
+FROM ae_court_decisions WHERE source = 'dubai_courts';
+
+\echo '=== arabic FTS smoke test (must return rows) ==='
+SELECT count(*) AS hits_for_labour_contract
+FROM ae_court_decisions
+WHERE source = 'dubai_courts' AND language = 'ar'
+  AND to_tsvector('arabic', coalesce(case_title,'') || ' ' || coalesce(full_text,''))
+      @@ plainto_tsquery('arabic', 'عقد العمل');
+
+\echo '=== whole table ==='
+SELECT source, count(*) FROM ae_court_decisions GROUP BY 1 ORDER BY 2 DESC;

--- a/scripts/uae/texts_pipeline.sh
+++ b/scripts/uae/texts_pipeline.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Phase 2 driver: wait for index walks, then fan out full-text fetches.
+# Politeness is enforced by Lambda reserved concurrency, not by this loop.
+set -u
+SD="${UAE_WORK_DIR:-$(cd "$(dirname "$0")" && pwd)/work}"
+mkdir -p "$SD"
+B="${UAE_BUCKET:?set UAE_BUCKET}"
+AWS="aws --profile ${UAE_PROFILE:-uae} --region ${UAE_REGION:-me-central-1}"
+LOG=$SD/texts_pipeline.log
+CONC=10
+BATCH=50
+: > "$LOG"
+say() { echo "$(date -u +%H:%M:%SZ) $*" >> "$LOG"; }
+
+say "waiting for index chains to finish"
+for i in $(seq 1 200); do
+    if grep -q "ALL. index chains finished" "$SD/index_chain.log" 2>/dev/null; then say "chains done"; break; fi
+    N=$($AWS s3 ls "s3://$B/index/" 2>/dev/null | grep -cE "stage[0-9]+_c[0-9]+")
+    say "index chunks so far: $N"
+    sleep 60
+done
+
+mkdir -p "$SD/idx" && $AWS s3 cp "s3://$B/index/" "$SD/idx/" --recursive --exclude "*" --include "stage*_c*.json.gz" >/dev/null 2>&1
+say "downloaded: $(ls "$SD/idx" | tr '\n' ' ')"
+
+python3 - "$SD" "$BATCH" >> "$LOG" 2>&1 <<'PY'
+import glob, gzip, json, os, sys
+sd, batch = sys.argv[1], int(sys.argv[2])
+seen, items, skipped = set(), [], 0
+for f in sorted(glob.glob(os.path.join(sd, "idx", "stage*_c*.json.gz"))):
+    rows = json.loads(gzip.open(f).read())
+    for r in rows:
+        # cassation (5) and appeal (3) only - first instance is out of scope
+        if str(r.get("stage")) not in ("5", "3"):
+            skipped += 1
+            continue
+        k = (r["subtype"], r["serial"], r["case_year"], r["decision_no"], r["stage"])
+        if k in seen:
+            continue
+        seen.add(k)
+        items.append({key: r[key] for key in
+                      ("subtype", "serial", "case_year", "decision_no", "stage")})
+    print("  %s -> %d rows (unique so far %d)" % (os.path.basename(f), len(rows), len(items)))
+os.makedirs(os.path.join(sd, "payloads"), exist_ok=True)
+n = 0
+for i in range(0, len(items), batch):
+    n += 1
+    with open(os.path.join(sd, "payloads", "b%05d.json" % n), "w") as fh:
+        json.dump({"mode": "texts", "timeout": 40, "delay": 0.25,
+                   "s3_key": "texts/b%05d.json.gz" % n,
+                   "items": items[i:i + batch]}, fh, ensure_ascii=False)
+print("TOTAL %d docs in %d batches (skipped %d first-instance rows)" % (len(items), n, skipped))
+open(os.path.join(sd, "batch_count.txt"), "w").write(str(n))
+PY
+
+TOTAL=$(cat "$SD/batch_count.txt" 2>/dev/null || echo 0)
+say "prepared $TOTAL batches"
+[ "$TOTAL" -eq 0 ] && { say "nothing to do"; exit 1; }
+
+$AWS lambda put-function-concurrency --function-name uae-fetch \
+     --reserved-concurrent-executions $CONC >/dev/null 2>&1 && say "reserved concurrency = $CONC"
+
+ls "$SD"/payloads/*.json | xargs -P 8 -I{} sh -c \
+  "aws --profile uae --region me-central-1 lambda invoke --function-name uae-fetch \
+   --invocation-type Event --cli-binary-format raw-in-base64-out \
+   --payload file://{} /dev/null >/dev/null 2>&1"
+say "all $TOTAL invocations queued"
+
+for i in $(seq 1 400); do
+    DONE=$($AWS s3 ls "s3://$B/texts/" 2>/dev/null | wc -l | tr -d ' ')
+    say "texts done: $DONE/$TOTAL"
+    [ "$DONE" -ge "$TOTAL" ] && { say "ALL TEXTS FETCHED"; break; }
+    sleep 60
+done
+$AWS lambda delete-function-concurrency --function-name uae-fetch >/dev/null 2>&1
+say "pipeline finished"


### PR DESCRIPTION
Adds `scripts/uae/` — the tooling behind the `ae_court_decisions` corpus.

## What's here

| File | Purpose |
|---|---|
| `harvest_difc.py` | DIFC judgments for a year, full text from HTML |
| `harvest_adgm.py` | ADGM judgments, text extracted from PDFs |
| `lambda/uae_fetch.py` | UAE-resident proxy (me-central-1): `fetch` / `walk` / `texts` |
| `index_chain.sh` | chained index walk per litigation stage, resumable |
| `texts_pipeline.sh` | fan-out full-text fetch behind the index walk |
| `build_dubai_jsonl.py` | joins index metadata with texts, emits load-ready JSONL |
| `sql/*.sql` | table DDL + idempotent loaders per source |

## Why a Lambda

DIFC and ADGM are reachable from anywhere. Dubai Courts, Dubai Pulse and the MOJ
portal refuse connections from non-UAE IPs — verified from both a Swiss IP and
prod's eu-central-1 address. EC2 in `me-central-1` is unusable (`RunInstances`
throttles region-wide across every instance family and both AZs), so the proxy is
a Lambda instead.

## State so far

`ae_court_decisions` on prod holds 5058 DIFC + ADGM judgments (2007-2026). The
Dubai index walk is running: cassation complete at 40,516 judgments, appeal in
progress.

## Notes for reviewers

Nothing here runs in CI or touches the app. Bucket, profile, region and work
directory come from env vars; no account identifiers or credentials in source.

The README records the non-obvious parts: the `__AJAX` hidden field OutSystems
pagination silently requires, the fact that only the litigation-stage filter
actually works, the quadratic cost of deep pagination, the request pacing that
stops the portal dropping the connection, and the terms-of-use position (a written
permission request went to Dubai Courts on 2026-08-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds UAE court harvesters and a Dubai Courts Lambda proxy to build the `ae_court_decisions` corpus (DIFC, ADGM, Dubai). Includes index walk, full-text fetch, JSONL builders, and SQL loaders with FTS indexes.

- New Features
  - DIFC: `harvest_difc.py` fetches yearly listings and extracts HTML full text.
  - ADGM: `harvest_adgm.py` downloads PDFs and extracts text via `pdftotext`.
  - Dubai Courts: `lambda/uae_fetch.py` (modes: `fetch`/`walk`/`texts`) in `me-central-1` to bypass geo-blocking, plus `index_chain.sh` (resumable stage walk) and `texts_pipeline.sh` (batched full-text).
  - Builder: `build_dubai_jsonl.py` joins index metadata with fetched texts into load-ready JSONL.
  - SQL: `sql/01_create_table.sql` creates `ae_court_decisions` with EN/AR FTS and trigram indexes; `02_load_difc_adgm.sql` and `03_load_dubai.sql` provide idempotent loaders.
  - Docs: `README.md` covers OutSystems pagination quirks, pacing, resume strategy, and terms-of-use notes.

- Migration
  - Deploy Lambda `uae-fetch` in `me-central-1` with env `HARVEST_BUCKET`; ensure `awscli` and `pdftotext` are available.
  - Set `UAE_BUCKET`, `UAE_PROFILE`, `UAE_REGION`; run `index_chain.sh`, then `texts_pipeline.sh`, then `build_dubai_jsonl.py <index_dir> <texts_dir> ae_dubai.jsonl`.
  - Load data: run `sql/01_create_table.sql`, `sql/02_load_difc_adgm.sql`, `sql/03_load_dubai.sql` after placing JSONL files in `/tmp` of the Postgres container.

<sup>Written for commit de3cd43f6860c9b2f6042450f48950cbd949f10c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

