### PR TITLE
fix(substrate): three defects the deployed smoke test found

### DIFF
--- a/docs/proposals/substrate-api-contract.md
+++ b/docs/proposals/substrate-api-contract.md
@@ -58,7 +58,7 @@ default of "good law".
 | 4 | `GET /{j}/decisions/{ecli}/citing` | who cites it |
 | 5 | `GET /{j}/decisions/{ecli}/cited` | what it cites, resolved |
 | 6 | `GET /{j}/decisions/{ecli}/chain` | the instance ladder with outcomes |
-| 7 | `GET /{j}/legislation/{lawId}/case-law?article=` | decisions applying a provision |
+| 7 | `GET /{j}/legislation/{lawId}/case-law?article=&order=` | decisions applying a provision |
 | 8 | `GET /{j}/legislation/{lawId}?as_of=` | the act, as in force on a date |
 | 9 | `GET /{j}/resolve?ref=` | any citation string to a canonical node |
 | 10 | `GET /{j}/changes?since=` | what changed, for subscriptions |
@@ -82,6 +82,16 @@ outcome of each appeal attached. Worth stating that this does not need a graph
 store: Dutch ladders are at most four deep and the query is a few milliseconds.
 Reach for Neo4j when the graph is EDRSR-sized (135M edges), not at 1M.
 
+The walk has to carry the path it already visited, and the answer has to collapse
+a link stored in both orientations. Both are the same lesson for Finland: an edge
+table filled by more than one builder will disagree with itself about which side
+is the child. Here 52,814 conclusion pairs exist twice, because the RDF builder
+followed the publisher's `psi:aanleg` while the case-number builder wrote the
+same edge the other way round, and the walk bounced between the two documents
+until it hit the depth cap and reported six rungs where there are two. The rule
+worth copying: the orientation stated by the source wins, and one link between
+two documents appears once.
+
 **1, search, and why ordering is a parameter.** Ranking with `ts_rank` over the
 full text costs **42 seconds** on this corpus: Postgres recomputes the tsvector
 for every matching row before `LIMIT` can apply. Ranking over the summary alone
@@ -90,8 +100,25 @@ silently, `order` is `relevance` (default), `authority` or `date`, and the
 response says which signal was used. When vectors land, `relevance` changes
 meaning and the contract does not.
 
+**7, case law on a provision, and why it takes `order` too.** The set is large
+enough that the ordering decides the answer: article 162 of BW Boek 6 has
+175,461 citing decisions, so any two of them are a sample, not a result. The
+first implementation deduplicated with `DISTINCT ON (ecli)`, which forces a sort
+by ECLI, and that sort then chose which rows survived the `LIMIT` — the endpoint
+answered with alphabetically-first tribunal rulings nobody cites. `order` is
+`authority` (default, most cited) or `date`. Ranking has to happen before the
+limit and away from the decisions table: ranking over `nl_precedent_status`
+(229k rows) is 242ms, walking the date index backwards and probing per row is
+1.0s worst case, and joining the 28GB table for the whole candidate set is 6.4s
+on this article and 22s on the criminal code.
+
 **10, changes.** Returns `next_since`, which is the caller's cursor for the next
-poll: polling from it never re-delivers and never skips. This is the RegTech
+poll: polling from it never re-delivers and never skips. It is also the endpoint
+a subscriber polls in a loop, so it is the one that must never be a sequential
+scan: without an index on `updated_at` it read the whole 28GB table to return two
+rows, 11,932ms of server time per poll. With `idx_nl_recht_updated_at` it is
+0.07ms and five buffers. Any jurisdiction added to this contract needs that index
+before the feed is advertised. This is the RegTech
 primitive that turns a purchase into a subscription, so it should exist from day
 one even before webhooks — and it is also the export risk, see below.
 

--- a/mcp_backend/src/routes/substrate-routes.ts
+++ b/mcp_backend/src/routes/substrate-routes.ts
@@ -107,6 +107,50 @@ function fail(res: Response, code: number, error: string, detail?: string) {
   return res.status(code).json({ error, ...(detail ? { detail } : {}) });
 }
 
+interface ChainRow {
+  direction: string; child_ecli: string; parent_ecli: string;
+  relation: string; method: string; outcome: string | null; depth: number;
+}
+
+/**
+ * One link between two documents must appear once, in the direction the
+ * publisher states.
+ *
+ * nl_instance_links holds 52,814 conclusion pairs twice, in opposite
+ * orientations, because two builders disagreed about which side is the child.
+ * The RDF builder follows psi:aanleg, so parent is the earlier instance and a
+ * PHR conclusion is the parent of the ruling it prepares; the case-number
+ * pairing builder wrote the same edge the other way round. Until the data is
+ * normalised (LEXAI-1901), the publisher-stated row wins here, so the answer
+ * does not depend on which of the two the walk happened to reach first.
+ *
+ * `direction` is recomputed from the surviving row whenever the link touches
+ * the queried decision, because dropping the mirror can otherwise leave a
+ * neighbour labelled from the orientation that was thrown away.
+ */
+function collapseMirrors(rows: ChainRow[], ecli: string) {
+  const best = new Map<string, ChainRow>();
+  for (const r of rows) {
+    const pair = [r.child_ecli, r.parent_ecli].sort();
+    const key = `${pair[0]}|${pair[1]}|${r.relation}`;
+    const kept = best.get(key);
+    if (!kept) { best.set(key, r); continue; }
+    // publisher-stated orientation first, then the shorter path
+    const better = (a: ChainRow, b: ChainRow) =>
+      a.method === b.method ? a.depth <= b.depth : a.method === 'rdf_relation';
+    if (better(r, kept)) best.set(key, r);
+  }
+  return [...best.values()]
+    .sort((a, b) => a.depth - b.depth)
+    .map(r => ({
+      direction: r.child_ecli === ecli ? 'earlier'
+        : r.parent_ecli === ecli ? 'later'
+          : r.direction,
+      from: r.child_ecli, to: r.parent_ecli,
+      relation: r.relation, outcome: r.outcome, depth: r.depth,
+    }));
+}
+
 export function createSubstrateRoutes(db: IDatabase): Router {
   const router = Router({ mergeParams: true });
 
@@ -134,7 +178,7 @@ export function createSubstrateRoutes(db: IDatabase): Router {
         { path: '/{j}/decisions/{ecli}/cited', returns: 'outbound citations, resolved' },
         { path: '/{j}/decisions/{ecli}/chain', returns: 'instance ladder with outcomes' },
         { path: '/{j}/legislation/{lawId}', params: 'as_of', returns: 'act and the edition in force' },
-        { path: '/{j}/legislation/{lawId}/case-law', params: 'article', returns: 'decisions applying it' },
+        { path: '/{j}/legislation/{lawId}/case-law', params: 'article, order', order: 'authority | date', returns: 'decisions applying it' },
         { path: '/{j}/resolve', params: 'ref', returns: 'canonical node for any citation string' },
         { path: '/{j}/changes', params: 'since, limit', returns: 'nodes changed since a timestamp' },
       ],
@@ -391,31 +435,41 @@ export function createSubstrateRoutes(db: IDatabase): Router {
       const ecli = String(req.params.ecli);
       // Recursive CTE rather than a graph store: NL ladders are at most four
       // deep, so a walk over an indexed edge table is the whole requirement.
+      //
+      // The walk carries the path it has already visited. Without that guard a
+      // pair stored in both orientations (52,814 of them, see collapseMirrors
+      // below) bounces the recursion back and forth until it hits the depth cap
+      // and reports a six-rung ladder between two documents.
       const rows = await db.query(
         `WITH RECURSIVE up AS (
-             SELECT child_ecli, parent_ecli, relation, outcome, 1 AS depth
+             SELECT child_ecli, parent_ecli, relation, method, outcome, 1 AS depth,
+                    ARRAY[child_ecli, parent_ecli] AS path
                FROM ${j.instanceLinksTable} WHERE child_ecli = $1
              UNION ALL
-             SELECT l.child_ecli, l.parent_ecli, l.relation, l.outcome, up.depth + 1
+             SELECT l.child_ecli, l.parent_ecli, l.relation, l.method, l.outcome,
+                    up.depth + 1, up.path || l.parent_ecli
                FROM ${j.instanceLinksTable} l JOIN up ON l.child_ecli = up.parent_ecli
-              WHERE up.depth < 6
+              WHERE up.depth < 6 AND NOT l.parent_ecli = ANY(up.path)
          ), down AS (
-             SELECT child_ecli, parent_ecli, relation, outcome, 1 AS depth
+             SELECT child_ecli, parent_ecli, relation, method, outcome, 1 AS depth,
+                    ARRAY[parent_ecli, child_ecli] AS path
                FROM ${j.instanceLinksTable} WHERE parent_ecli = $1
              UNION ALL
-             SELECT l.child_ecli, l.parent_ecli, l.relation, l.outcome, down.depth + 1
+             SELECT l.child_ecli, l.parent_ecli, l.relation, l.method, l.outcome,
+                    down.depth + 1, down.path || l.child_ecli
                FROM ${j.instanceLinksTable} l JOIN down ON l.parent_ecli = down.child_ecli
-              WHERE down.depth < 6
+              WHERE down.depth < 6 AND NOT l.child_ecli = ANY(down.path)
          )
-         SELECT 'earlier' AS direction, * FROM up
-         UNION ALL SELECT 'later', * FROM down`, [ecli]);
+         SELECT 'earlier' AS direction, child_ecli, parent_ecli, relation, method, outcome, depth
+           FROM up
+         UNION ALL
+         SELECT 'later', child_ecli, parent_ecli, relation, method, outcome, depth
+           FROM down
+         ORDER BY depth`, [ecli]);
 
       res.json({
         jurisdiction: j.code, ecli,
-        chain: rows.rows.map((r: any) => ({
-          direction: r.direction, from: r.child_ecli, to: r.parent_ecli,
-          relation: r.relation, outcome: r.outcome, depth: r.depth,
-        })),
+        chain: collapseMirrors(rows.rows, ecli),
       });
     } catch (err) {
       logger.error('[Substrate] chain failed', { error: String(err) });
@@ -431,23 +485,79 @@ export function createSubstrateRoutes(db: IDatabase): Router {
       let articleClause = '';
       if (req.query.article) { params.push(req.query.article); articleClause = `AND c.article = $${params.length}`; }
       params.push(clampLimit(req.query.limit, 50));
+      const limitParam = `$${params.length}`;
 
-      const rows = await db.query(
-        `SELECT DISTINCT ON (d.ecli) d.ecli, d.court_name, d.decision_date, c.article,
-                d.summary, coalesce(p.cited_by_count,0) AS cited_by_count
-           FROM ${j.statuteEdgesTable} c
-           JOIN ${j.decisionsTable} d ON d.ecli = c.from_ecli
-           LEFT JOIN ${j.precedentTable} p ON p.ecli = d.ecli
-          WHERE c.law_id = $1 ${articleClause}
-          ORDER BY d.ecli, d.decision_date DESC
-          LIMIT $${params.length}`, params);
+      // Ordering is explicit here for the same reason as in /search, and the
+      // ranking has to happen before the LIMIT rather than after the dedup.
+      // The old query deduplicated with DISTINCT ON (d.ecli), which forces
+      // ORDER BY d.ecli, and that sort then decided which rows survived: for
+      // article 162 of BW Boek 6 (175,461 citing decisions) the endpoint
+      // returned two uncited 2000-2001 tribunal rulings, alphabetically first.
+      //
+      // Both shapes below pick the N decisions cheaply and only then touch the
+      // 28GB decisions table for those N. Joining it for the whole candidate
+      // set instead costs 6.4s here and 22s on the criminal code.
+      const order = String(req.query.order || 'authority');
+
+      // The articles this decision cites from this act, for the returned rows
+      // only. Cheap per row through idx_nl_lc_from, and it answers "which
+      // provision" without a second call.
+      const articlesLateral =
+        `LEFT JOIN LATERAL (
+             SELECT array_agg(DISTINCT c2.article) FILTER (WHERE c2.article IS NOT NULL) AS articles
+               FROM ${j.statuteEdgesTable} c2
+              WHERE c2.from_ecli = d.ecli AND c2.law_id = $1
+         ) arts ON true`;
+
+      const sql = order === 'date'
+        // Newest first: walk decision_date backwards on its index and probe the
+        // edge table per row, so the sort never sees the candidate set. 1.0s
+        // worst case (criminal code, 1.05M edges) against 22s for a full join.
+        ? `WITH picked AS MATERIALIZED (
+               SELECT d.ecli FROM ${j.decisionsTable} d
+                WHERE EXISTS (SELECT 1 FROM ${j.statuteEdgesTable} c
+                               WHERE c.from_ecli = d.ecli AND c.law_id = $1 ${articleClause})
+                ORDER BY d.decision_date DESC NULLS LAST
+                LIMIT ${limitParam}
+           )
+           SELECT d.ecli, d.court_name, d.decision_date, d.summary,
+                  coalesce(p.cited_by_count,0) AS cited_by_count, arts.articles
+             FROM picked
+             JOIN ${j.decisionsTable} d ON d.ecli = picked.ecli
+             LEFT JOIN ${j.precedentTable} p ON p.ecli = d.ecli
+             ${articlesLateral}
+            ORDER BY d.decision_date DESC NULLS LAST`
+        // Most cited first: rank over nl_precedent_status (229k rows) rather
+        // than over the decisions table.
+        : `WITH cand AS MATERIALIZED (
+               SELECT DISTINCT c.from_ecli FROM ${j.statuteEdgesTable} c
+                WHERE c.law_id = $1 ${articleClause}
+           ), ranked AS MATERIALIZED (
+               SELECT cand.from_ecli, coalesce(p.cited_by_count,0) AS cited_by_count
+                 FROM cand LEFT JOIN ${j.precedentTable} p ON p.ecli = cand.from_ecli
+                ORDER BY cited_by_count DESC
+                LIMIT ${limitParam}
+           )
+           SELECT d.ecli, d.court_name, d.decision_date, d.summary,
+                  r.cited_by_count, arts.articles
+             FROM ranked r
+             JOIN ${j.decisionsTable} d ON d.ecli = r.from_ecli
+             ${articlesLateral}
+            ORDER BY r.cited_by_count DESC, d.decision_date DESC NULLS LAST`;
+
+      const rows = await db.query(sql, params);
 
       res.json({
         jurisdiction: j.code, law_id: req.params.lawId,
-        article: req.query.article ?? null, count: rows.rows.length,
+        article: req.query.article ?? null,
+        order,
+        order_note: order === 'date'
+          ? 'most recently decided first'
+          : 'most cited first, by inbound citations inside this corpus',
+        count: rows.rows.length,
         decisions: rows.rows.map((r: any) => ({
           ecli: r.ecli, court: r.court_name, date: r.decision_date,
-          article: r.article,
+          articles: r.articles ?? [],
           summary: r.summary ? String(r.summary).slice(0, 300) : null,
           cited_by_count: Number(r.cited_by_count),
         })),

--- a/scripts/nl/183_nl_decisions_updated_at_concurrently.sql
+++ b/scripts/nl/183_nl_decisions_updated_at_concurrently.sql
@@ -1,0 +1,44 @@
+-- Index for the substrate /changes feed (LEXAI-1902).
+--
+-- GET /api/v1/substrate/nl/changes?since=... asks for the rows updated after a
+-- timestamp, newest cursor last. It is the one endpoint an integrator polls in a
+-- loop, and it was the slowest thing in the contract: 12.5s over the wire.
+--
+-- EXPLAIN ANALYZE on prod, since=2026-07-25, limit 2:
+--   Parallel Seq Scan on nl_rechtspraak_decisions, 6 workers
+--   Buffers: shared hit=53,864 read=668,131
+--   JIT 1,455ms, Execution Time 11,932ms
+-- There was no index on updated_at at all, so every poll read the whole 28GB
+-- table to return two rows.
+--
+-- Kept out of the numbered migrations for the same reason as 179b: the runner
+-- sends a file as one query inside an implicit transaction, and CREATE INDEX
+-- CONCURRENTLY cannot run there, while a plain build would hold a write lock on
+-- a live 3.7M-row table.
+--
+-- Run:
+--   scp scripts/nl/183_nl_decisions_updated_at_concurrently.sql prod:/tmp/
+--   ssh prod "docker cp /tmp/183_nl_decisions_updated_at_concurrently.sql \
+--     secondlayer-postgres-prod:/tmp/ && docker exec secondlayer-postgres-prod \
+--     psql -U secondlayer -d secondlayer_prod -f /tmp/183_nl_decisions_updated_at_concurrently.sql"
+--
+-- An interrupted CONCURRENTLY build leaves an INVALID index behind, so the
+-- verification at the bottom is part of the run, not an optional extra.
+
+\timing on
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_nl_recht_updated_at
+    ON nl_rechtspraak_decisions (updated_at);
+
+-- ---------------------------------------------------------------------------
+-- Verify: the index must be valid, and the feed query must use it.
+-- ---------------------------------------------------------------------------
+SELECT indexrelid::regclass AS invalid_index
+FROM pg_index WHERE NOT indisvalid;
+
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT ecli, court_name, decision_date, updated_at
+  FROM nl_rechtspraak_decisions
+ WHERE updated_at >= '2026-07-25T00:00:00Z'::timestamptz
+ ORDER BY updated_at ASC
+ LIMIT 2;


### PR DESCRIPTION
Smoke test of all ten substrate endpoints through `https://legal.org.ua` with a real JWT. All eleven routes answered 200, and three of them answered wrongly or too slowly.

## 1. `/chain` invented instances (LEXAI-1901)

`GET /nl/decisions/ECLI:NL:HR:1990:ZC8515/chain` returned **12 rows containing 2 unique edges**, depth up to 6.

Two causes, both fixed here:

- the recursive CTE had no cycle guard;
- `nl_instance_links` holds **52,814 conclusion pairs in both orientations**. `build_instance_links_rdf_year.sql` follows the publisher's `psi:aanleg` (parent is the earlier instance), `build_instance_links_phr.sql` wrote the same edge the other way round.

The walk now carries its visited path, and `collapseMirrors` reports one link between two documents once, keeping the orientation the publisher states. Verified on prod:

| | before | after |
|---|---|---|
| `HR:1990:ZC8515` | 12 rows, depth 6 | 1 row, depth 1 |
| `HR:2020:940` (real ladder) | HR → Hof → Rechtbank | unchanged, outcomes intact |

The data itself is still inconsistent; normalising the 52,814 mirrored rows is a separate call, since it means deleting or flipping rows on prod.

## 2. `/changes` was a sequential scan (LEXAI-1902)

12.5s over the wire on the one endpoint a subscriber polls in a loop. `EXPLAIN ANALYZE`: Parallel Seq Scan over 3.7M rows, 668,131 blocks read, JIT 1,455ms, **11,932ms** to return two rows. There was no index on `updated_at` at all.

`idx_nl_recht_updated_at` is built on prod already (`CONCURRENTLY`, 26 MB, `indisvalid` checked). Same query now: Index Scan, five buffers, **0.074ms**. The script lives in `scripts/nl/183_...sql` next to 179b, for the same reason: the migration runner wraps a file in a transaction and `CONCURRENTLY` cannot run there.

## 3. `/legislation/{id}/case-law` ranked by alphabet (LEXAI-1903)

Article 162 of BW Boek 6 is `onrechtmatige daad`, 175,461 citing decisions. The endpoint returned two College van Beroep voor het bedrijfsleven rulings from 2000 and 2001, `summary: "-"`, `cited_by_count: 0`, because `DISTINCT ON (d.ecli)` forces `ORDER BY d.ecli` and that sort decided what survived the `LIMIT`.

Ranking now happens before the limit, and away from the 28GB table. Measured on prod:

| shape | BW6 art. 162 | Wetboek van Strafrecht |
|---|---|---|
| join the whole candidate set (rejected) | 6.4s | 22.0s |
| `order=authority`, rank over `nl_precedent_status` | **242ms** | **536ms** |
| `order=date`, walk the date index and probe | **249ms** | **1.05s** |

Top result for article 162 is now `ECLI:NL:HR:2019:793`, the overzichtsarrest, 1,100 inbound citations.

**Response change:** each row now carries `articles` (every article of that act the decision cites) instead of a single `article`. The contract doc is updated in the same commit.

## Verification

- `tsc` clean for this file; the three pre-existing errors (core-overlay `core-loader.ts`, `registry-catalog.ts`) are untouched.
- Every SQL shape above was run on prod before being written into the route.
- Post-deploy: re-run the eleven-call smoke and confirm chain returns 1 row, changes is sub-second, case-law leads with HR 2019:793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three substrate endpoint defects found in smoke tests: corrects instance chain walks, makes the changes feed fast, and ranks case-law results with a new order option and proper article lists.

- **Bug Fixes**
  - LEXAI-1901 `/chain`: add a cycle guard and collapse mirrored edges; keep publisher-stated orientation. Example goes from 12 rows (depth 6) to 1 (depth 1). Real ladders unchanged.
  - LEXAI-1902 `/changes`: add `updated_at` index (`idx_nl_recht_updated_at`) for the feed. Query shifts from seq scan (~12.5s) to index scan (~0.07ms).
  - LEXAI-1903 `/legislation/{id}/case-law`: rank before `LIMIT` and add `order=authority|date` (default `authority`). Rows now include `articles` (array). Contract updated in `docs/proposals/substrate-api-contract.md`.

- **Migration**
  - Run `scripts/nl/183_nl_decisions_updated_at_concurrently.sql` on prod to build the index concurrently and verify it’s valid and used.

<sup>Written for commit a9672ef24d8ec082c93b6fc35253b68465e7d130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

