### PR TITLE
fix(deploy): stop re-attaching live containers to the network (LEXAI-1795)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -875,26 +875,25 @@ jobs:
             # --- 5. Save active colors ---
             printf 'backend=%s\nfrontend=%s\n' "\$BACKEND_COLOR" "\$FRONTEND_COLOR" > .active-colors
 
-            # --- 5a. Add canonical DNS aliases for opendata-sync ---
-            # opendata-sync connects to app-prod:3000 and app-openreyestr-prod:3005
-            # but blue-green containers have color suffixes — add aliases so DNS resolves
-            NETWORK="deployment_secondlayer-prod-network"
-            if [ "\$BACKEND_COLOR" = "green" ]; then
-              BE_CONTAINER="secondlayer-app-prod-green"
-              OR_CONTAINER="openreyestr-app-prod-green"
-              RADA_CONTAINER="rada-mcp-app-prod-green"
-            else
-              BE_CONTAINER="secondlayer-app-prod"
-              OR_CONTAINER="openreyestr-app-prod"
-              RADA_CONTAINER="rada-mcp-app-prod"
-            fi
-            echo "Adding canonical DNS aliases (app-prod, app-openreyestr-prod, rada-mcp-app-prod) to \$BE_CONTAINER, \$OR_CONTAINER, \$RADA_CONTAINER"
-            docker network disconnect "\$NETWORK" "\$BE_CONTAINER" 2>/dev/null || true
-            docker network connect --alias app-prod "\$NETWORK" "\$BE_CONTAINER" || true
-            docker network disconnect "\$NETWORK" "\$OR_CONTAINER" 2>/dev/null || true
-            docker network connect --alias app-openreyestr-prod "\$NETWORK" "\$OR_CONTAINER" || true
-            docker network disconnect "\$NETWORK" "\$RADA_CONTAINER" 2>/dev/null || true
-            docker network connect --alias rada-mcp-app-prod "\$NETWORK" "\$RADA_CONTAINER" || true
+            # --- 5a. Canonical DNS aliases ---
+            # opendata-sync dials app-prod:3000, app-openreyestr-prod:3005 and
+            # rada-mcp-app-prod:3001, while blue-green containers carry a colour
+            # suffix. Those aliases now live in docker-compose.prod.yml under each
+            # service's networks: block, so a container is created with them.
+            #
+            # They used to be attached here, to the already-running container, with
+            # docker network disconnect + connect --alias. That re-attach hands the
+            # container a NEW IP (measured 172.18.0.34 -> 172.18.0.4 about a minute
+            # after start), and every TCP connection the process had already opened
+            # keeps a source address that no longer exists on eth0. Nothing those
+            # sockets send is delivered and no RST or FIN comes back, so node-redis,
+            # which has no per-command timeout, never sees an error and never
+            # reconnects: it writes into a black hole (13,728 bytes stuck in tx_queue
+            # when this was caught). Every cache read then costs the full 2500ms
+            # CacheAdapter guard, the rate limiter silently falls back to per-process
+            # memory, and only the kernel's TCP keepalive ends it, about 15 minutes
+            # later. That was LEXAI-1795, once per deploy, for every one of the three
+            # services listed above. Do not re-attach a live container to a network.
 
             # Restart monitoring if needed
             if [ "${MONITORING_CHANGED}" = "true" ]; then

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -319,7 +319,9 @@ services:
       retries: 3
       start_period: 30s
     networks:
-      - secondlayer-prod-network
+      secondlayer-prod-network:
+        aliases:
+        - rada-mcp-app-prod
     deploy:
       resources:
         limits:
@@ -393,7 +395,9 @@ services:
       start_period: 30s
     restart: unless-stopped
     networks:
-      - secondlayer-prod-network
+      secondlayer-prod-network:
+        aliases:
+        - app-openreyestr-prod
     deploy:
       resources:
         limits:
@@ -674,7 +678,9 @@ services:
       start_period: 60s
     restart: unless-stopped
     networks:
-    - secondlayer-prod-network
+      secondlayer-prod-network:
+        aliases:
+        - app-prod
     deploy:
       resources:
         limits:
@@ -1089,7 +1095,9 @@ services:
       start_period: 60s
     restart: unless-stopped
     networks:
-    - secondlayer-prod-network
+      secondlayer-prod-network:
+        aliases:
+        - app-prod
     deploy:
       resources:
         limits:
@@ -1146,7 +1154,9 @@ services:
       retries: 3
       start_period: 30s
     networks:
-      - secondlayer-prod-network
+      secondlayer-prod-network:
+        aliases:
+        - rada-mcp-app-prod
     deploy:
       resources:
         limits:
@@ -1195,7 +1205,9 @@ services:
       start_period: 30s
     restart: unless-stopped
     networks:
-      - secondlayer-prod-network
+      secondlayer-prod-network:
+        aliases:
+        - app-openreyestr-prod
     deploy:
       resources:
         limits:

--- a/mcp_backend/src/infrastructure/adapters/__tests__/cache-adapter.test.ts
+++ b/mcp_backend/src/infrastructure/adapters/__tests__/cache-adapter.test.ts
@@ -52,3 +52,65 @@ describe('CacheAdapter — fast-fail on a hung Redis client', () => {
     await expect(adapter.ping()).resolves.toBe(false);
   });
 });
+
+/**
+ * Regression (LEXAI-1795, root cause found 2026-08-01): a deploy step re-attached the running
+ * container to the docker network, which changed its IP, and every socket the process already
+ * held became a black hole — writes are never delivered, and no RST or FIN comes back. node-redis
+ * therefore never emits an error and never reconnects, so every op fell to the timeout above for
+ * ~15 minutes, until the kernel's TCP keepalive finally killed the socket. The deploy no longer
+ * does that, but any future silent socket death must not need a human or a kernel timer: after a
+ * few consecutive timeouts the adapter drops the socket itself.
+ */
+describe('CacheAdapter — self-heal after repeated timeouts', () => {
+  const hang = () => new Promise(() => {});
+
+  function makeHungClient() {
+    return makeClient({
+      get: jest.fn(hang),
+      isOpen: true,
+      destroy: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+    });
+  }
+
+  it('does not touch the socket while timeouts are below the threshold', async () => {
+    const client = makeHungClient();
+    const adapter = new CacheAdapter(client);
+    await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+    await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+    expect(client.destroy).not.toHaveBeenCalled();
+  });
+
+  it('drops and re-opens the connection after three consecutive timeouts', async () => {
+    const client = makeHungClient();
+    const adapter = new CacheAdapter(client);
+    for (let i = 0; i < 3; i++) {
+      await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+    }
+    await new Promise(r => setImmediate(r));   // reconnect runs off the failing call
+    expect(client.destroy).toHaveBeenCalledTimes(1);
+    expect(client.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgets the streak once an op succeeds', async () => {
+    const get = jest.fn()
+      .mockImplementationOnce(hang)
+      .mockImplementationOnce(hang)
+      .mockResolvedValueOnce('5')
+      .mockImplementationOnce(hang)
+      .mockImplementationOnce(hang);
+    const client = makeHungClient();
+    client.get = get;
+    const adapter = new CacheAdapter(client);
+
+    await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+    await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+    await expect(adapter.get('k')).resolves.toBe('5');
+    await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+    await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+
+    await new Promise(r => setImmediate(r));
+    expect(client.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/mcp_backend/src/infrastructure/adapters/cache-adapter.ts
+++ b/mcp_backend/src/infrastructure/adapters/cache-adapter.ts
@@ -22,17 +22,67 @@ type RedisClient = ReturnType<typeof createClient>;
 // failing fast on a genuinely dead socket (which keepAlive/pingInterval also detect ~30s).
 const REDIS_OP_TIMEOUT_MS = Number(process.env.REDIS_OP_TIMEOUT_MS || 2500);
 
+// How many consecutive timeouts mean the socket is gone rather than busy. Three is past any
+// plausible burst of slowness (that is 7.5s of nothing) and still well inside the ~15 minutes
+// the kernel used to take to notice — see forceReconnect below.
+const RECONNECT_AFTER_TIMEOUTS = Number(process.env.REDIS_RECONNECT_AFTER_TIMEOUTS || 3);
+
 export class CacheAdapter implements ICachePort {
   private client: RedisClient;
+  private consecutiveTimeouts = 0;
+  private reconnecting = false;
 
   constructor(client: RedisClient) {
     this.client = client;
   }
 
+  /**
+   * Drop the socket ourselves when it stops answering.
+   *
+   * A TCP connection can die without anyone being told: on 2026-08-01 a deploy step re-attached
+   * the running container to the docker network, its IP changed under the live process, and every
+   * open socket became a black hole. Writes queued in the kernel (13,728 bytes stuck in tx_queue),
+   * no RST or FIN came back, so node-redis never emitted an error, never ran its reconnect
+   * strategy, and kept writing into it. Redis was healthy the whole time; a fresh client from the
+   * same container answered in 1ms. Recovery only came when TCP keepalive gave up, about 15
+   * minutes later, and until then every cache read cost the full timeout above and the rate
+   * limiter ran on per-process memory.
+   *
+   * The deploy no longer does that (aliases are set at container creation), but a client that can
+   * only be rescued by a kernel timer is a client with a hole in it. Consecutive timeouts are the
+   * one signal available, since the socket itself reports nothing, so past the threshold we
+   * destroy it and reconnect. destroy() rather than quit(): a graceful QUIT writes to the same
+   * dead socket and waits for a reply that will never come.
+   */
+  private async forceReconnect(): Promise<void> {
+    if (this.reconnecting) return;
+    this.reconnecting = true;
+    try {
+      logger.warn('[Cache] Redis unresponsive, dropping the socket and reconnecting', {
+        consecutiveTimeouts: this.consecutiveTimeouts,
+      });
+      const client = this.client as unknown as { destroy?: () => void; disconnect?: () => Promise<void> };
+      if (typeof client.destroy === 'function') {
+        client.destroy();
+      } else if (typeof client.disconnect === 'function') {
+        await client.disconnect();
+      }
+      await this.client.connect();
+      this.consecutiveTimeouts = 0;
+      logger.info('[Cache] Redis reconnected');
+    } catch (err) {
+      // Leave the counter high so the next timeout tries again rather than waiting for a fresh
+      // streak; node-redis reconnectStrategy also keeps retrying once the socket is really closed.
+      logger.error('[Cache] Redis reconnect failed', { error: String(err) });
+    } finally {
+      this.reconnecting = false;
+    }
+  }
+
   private async withTimeout<T>(op: Promise<T>, label: string): Promise<T> {
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      return await Promise.race([
+      const result = await Promise.race([
         op,
         new Promise<never>((_, reject) => {
           timer = setTimeout(
@@ -41,6 +91,18 @@ export class CacheAdapter implements ICachePort {
           );
         }),
       ]);
+      this.consecutiveTimeouts = 0;
+      return result;
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('timed out after')) {
+        this.consecutiveTimeouts += 1;
+        if (this.consecutiveTimeouts >= RECONNECT_AFTER_TIMEOUTS) {
+          // deliberately not awaited: the caller is already degrading to its fallback and must
+          // not wait for a reconnect on top of the timeout it just paid
+          void this.forceReconnect();
+        }
+      }
+      throw err;
     } finally {
       if (timer) clearTimeout(timer);
     }

--- a/mcp_backend/src/utils/__tests__/redis-client.test.ts
+++ b/mcp_backend/src/utils/__tests__/redis-client.test.ts
@@ -95,12 +95,17 @@ describe('redis-client', () => {
       expect(logger.warn).toHaveBeenCalled();
     });
 
-    it('should register event handlers on the client', async () => {
+    // The names must be the ones node-redis actually emits. This test used to require
+    // 'disconnect', which node-redis has never emitted, so it locked in a listener that could
+    // never fire and a closed socket was logged nowhere.
+    it('should register event handlers the client actually emits', async () => {
       await getRedisClient();
       const eventNames = mockRedisOn.mock.calls.map((c: any[]) => c[0]);
       expect(eventNames).toContain('error');
       expect(eventNames).toContain('connect');
-      expect(eventNames).toContain('disconnect');
+      expect(eventNames).toContain('end');
+      expect(eventNames).toContain('reconnecting');
+      expect(eventNames).not.toContain('disconnect');
     });
   });
 

--- a/mcp_backend/src/utils/redis-client.ts
+++ b/mcp_backend/src/utils/redis-client.ts
@@ -36,8 +36,16 @@ export async function getRedisClient(): Promise<ReturnType<typeof createClient> 
       logger.info('[Redis] Connected successfully');
     });
 
-    redisClient.on('disconnect', () => {
-      logger.warn('[Redis] Disconnected');
+    // node-redis emits 'end', not 'disconnect' — the old listener could never fire, so a socket
+    // that closed did it silently. 'reconnecting' is logged too: when the client is stuck writing
+    // into a dead socket (see CacheAdapter.forceReconnect) the absence of these lines is itself
+    // the diagnosis.
+    redisClient.on('end', () => {
+      logger.warn('[Redis] Connection closed');
+    });
+
+    redisClient.on('reconnecting', () => {
+      logger.warn('[Redis] Reconnecting');
     });
 
     await redisClient.connect();


### PR DESCRIPTION
Root cause of LEXAI-1795, found while checking why every substrate endpoint had a flat 2.55s floor after the last deploy. It is not Redis, not load, and not the event loop.

## What happens

`deploy-prod.yml` step 5a adds canonical DNS aliases for opendata-sync with `docker network disconnect` + `connect --alias` against containers that are **already running and serving**. The re-attach hands the container a new IP (measured `172.18.0.34` → `172.18.0.4`, about a minute after the process started), while the Node process keeps every TCP connection it had already opened, each with a source address that no longer exists on `eth0`. Nothing they send is delivered, and no RST or FIN comes back.

node-redis has no per-command timeout, so writing into that black hole raises nothing: no `error` event, no reconnect strategy. Recovery comes only from TCP keepalive giving up, ~15 minutes later.

**Cost, once per deploy, for backend + openreyestr + rada:** rate limiter silently on per-process memory (the advertised 3,000/min global limit is not enforced), every cache read costs 2.5s, every response including `/health` carries +2.5s.

## Evidence

| Layer | Observation |
|---|---|
| App | response time exactly 2.55s, response leaves immediately after → event loop healthy, timer on schedule |
| Client | fresh client in the same container, same `REDIS_URL`: connect 12ms, GET 0-1ms |
| Redis | `CLIENT LIST` has no node-redis connection from the container's current IP |
| Socket | `/proc/net/tcp` shows ESTABLISHED sockets to `:6379` with a local IP no container owns, `tx_queue` = 13,728 / 1,059 / 1,757 bytes unacknowledged |
| Timeline | orphaned ~13:45 UTC, last timeout 14:00:06, new connection ~14:00:5x — the kernel, not the app |

## Changes

1. **Aliases move to compose.** All six blue/green app services now declare `networks: secondlayer-prod-network: aliases: [...]`, so the container is created with the alias and is never re-attached. Step 5a is deleted, replaced by a comment explaining why re-attaching a live container is not allowed.
2. **`CacheAdapter` self-heals.** Three consecutive timeouts (7.5s of silence) mean the socket is gone, not busy: it calls `destroy()` + `connect()`. `destroy()` rather than `quit()`, since a graceful QUIT writes to the same dead socket and waits for a reply that never comes. Threshold is env-overridable via `REDIS_RECONNECT_AFTER_TIMEOUTS`.
3. **`redis-client.ts` listened for `disconnect`**, an event node-redis has never emitted, so a closed socket was logged nowhere. Now `end` and `reconnecting`. The existing unit test asserted the non-existent event, so it was holding the bug in place; it now asserts the real ones.

## Behaviour change worth knowing

During the blue-green overlap both colours briefly answer to `app-prod`, instead of the alias moving to the new colour at the very end. Both are healthy and serving in that window, and the old colour is stopped and removed right after.

## Verification

- `tsc` clean; 20/20 tests in the two Redis suites pass. The self-heal tests were written first and failed before the fix (`destroy` called 0 times).
- `docker compose config` validates; all six services show the alias.
- Post-merge check on prod: the container IP must be the one it was created with, no `Redis GET timed out` lines after the deploy, and `/health` sub-100ms from the first minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops re-attaching live containers to the Docker network during prod deploys to prevent orphaned Redis sockets and the post-deploy 2.5s latency floor. Addresses LEXAI-1795 by moving DNS aliases into compose and adding Redis client self-healing and correct event logging.

- **Bug Fixes**
  - Move canonical DNS aliases into `deployment/docker-compose.prod.yml` under each service’s `networks` to set aliases at container creation; remove deploy step 5a in `deploy-prod.yml` so containers keep their IPs and sockets aren’t orphaned.
  - Add Redis self-heal in `CacheAdapter`: after 3 consecutive timeouts (config via `REDIS_RECONNECT_AFTER_TIMEOUTS`), call `destroy()` then `connect()` instead of waiting for kernel keepalive; per-op timeout remains controlled by `REDIS_OP_TIMEOUT_MS`.
  - Fix Redis client listeners: use `end` and `reconnecting` (not the non-existent `disconnect`) and update tests; ensures closed sockets and reconnect attempts are logged.
  - Behavior change: during blue‑green overlap both colors briefly answer the canonical alias; the old color is stopped immediately after.

<sup>Written for commit 80c88a36ac2182d5cea4a661b99a17fea513e52a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

