### PR TITLE
fix(uae): stop the harvesters reporting success when they did nothing

### DIFF
--- a/scripts/uae/README.md
+++ b/scripts/uae/README.md
@@ -23,6 +23,7 @@ harvest_adgm.py        ADGM judgments (PDF)          -> JSONL
 lambda/uae_fetch.py    UAE-resident proxy: fetch | walk | texts
 index_chain.sh         chained index walk per litigation stage
 texts_pipeline.sh      fan-out full-text fetch behind the index walk
+fetch_batch.sh         one text batch through the Lambda (idempotent)
 build_dubai_jsonl.py   join index metadata + texts   -> JSONL
 sql/01_create_table.sql
 sql/02_load_difc_adgm.sql
@@ -39,7 +40,7 @@ python3 harvest_adgm.py all adgm_all.jsonl
 # Dubai: needs the Lambda deployed in me-central-1 and an AWS profile for it
 export UAE_BUCKET=<harvest bucket>      # required
 export UAE_PROFILE=uae UAE_REGION=me-central-1
-./index_chain.sh                        # index walk, stage by stage
+UAE_STAGES="5 3" ./index_chain.sh       # index walk, stage by stage (5=cassation, 3=appeal, 1=first instance)
 ./texts_pipeline.sh                     # full texts for the indexed rows
 python3 build_dubai_jsonl.py <index_dir> <texts_dir> ae_dubai.jsonl
 ```
@@ -75,9 +76,18 @@ returning `RemoteDisconnected` after 20-50 pages. At 0.8 s it runs for the full
 Lambda budget without a single drop. `index_chain.sh` also sleeps 60 s between
 chunks.
 
-**Async Lambda invocations were unreliable here** — they started and died without
-writing anything, while CloudWatch reported zero errors and zero dropped events.
-Everything now uses synchronous invokes with `--cli-read-timeout 0`.
+**Async Lambda invocations do not work here.** They are accepted with 202 and
+never execute: zero `Invocations`, zero `Errors`, zero `AsyncEventsDropped`. It
+cost two silent stalls (the index walk, then 3114 queued text batches that fetched
+nothing). Everything uses synchronous invokes with `--cli-read-timeout 0`.
+
+**Two failure modes that report success — check counts, not exit codes.**
+`index_chain.sh` used to stop at its chunk cap and return 0, so an appeal walk that
+was 385 pages short looked complete; it now returns 2 and logs `TRUNCATED`. And BSD
+`xargs -I{}` with a long inline script dies with "command line cannot be assembled,
+too long" while the surrounding pipeline happily logs that every batch was
+launched — hence `fetch_batch.sh` as a separate file. Always compare the row count
+you got against the count you expected.
 
 **Resume is by saved session, not by re-walking.** Each chunk stores cookies +
 `__OSVSTATE` + the next page target in S3, so the next invocation continues with

--- a/scripts/uae/fetch_batch.sh
+++ b/scripts/uae/fetch_batch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Fetch one batch of judgment texts through the UAE Lambda.
+# Idempotent: an existing non-empty response file means the batch is done, so a
+# re-run of the pipeline costs nothing and never refetches.
+# Kept as its own script because BSD xargs cannot assemble a long -I{} command
+# ("command line cannot be assembled, too long") and silently does nothing.
+SD="${UAE_WORK_DIR:-$(cd "$(dirname "$0")" && pwd)/work}"
+f="$1"; b=$(basename "$f" .json); out="$SD/resp/$b.json"
+[ -s "$out" ] && exit 0
+aws --profile "${UAE_PROFILE:-uae}" --region "${UAE_REGION:-me-central-1}" lambda invoke \
+    --function-name uae-fetch --cli-read-timeout 0 --cli-connect-timeout 60 \
+    --cli-binary-format raw-in-base64-out --payload "file://$f" "$out" >/dev/null 2>&1

--- a/scripts/uae/index_chain.sh
+++ b/scripts/uae/index_chain.sh
@@ -29,7 +29,7 @@ chain() {
             n=0
         fi
     fi
-    while [ $n -lt 30 ]; do
+    while [ $n -lt ${UAE_MAX_CHUNKS:-80} ]; do
         n=$((n+1))
         local ck=$(printf "index/stage%s_c%02d.json.gz" "$S" "$n")
         local sk=$(printf "state/stage%s_c%02d.json.gz" "$S" "$n")
@@ -66,7 +66,8 @@ print('ok=%s rows=%s last_page=%s stopped_early=%s err=%s%s' % (
             say "$S" "no further state -> stage $S COMPLETE after $n chunks"; return 0
         fi
     done
-    say "$S" "hit 12-chunk cap"
+    say "$S" "TRUNCATED: hit the ${UAE_MAX_CHUNKS:-80}-chunk cap without reaching the end"
+    return 2
 }
 
 # Sequential: one stage at a time, no self-competition for the portal.
@@ -79,10 +80,12 @@ for i in $(seq 1 24); do
     sleep 30
 done
 
-for spec in "5 0.8" "3 0.8" "1 0.8"; do
-    set -- $spec
-    say "ALL" "=== starting stage $1 ==="
-    chain "$1" "$2"
-    say "ALL" "=== stage $1 returned $? ==="
+DELAY="${UAE_DELAY:-0.8}"
+for S in ${UAE_STAGES:-5 3}; do
+    say "ALL" "=== starting stage $S ==="
+    chain "$S" "$DELAY"
+    rc=$?
+    say "ALL" "=== stage $S returned $rc ==="
+    [ $rc -eq 2 ] && say "ALL" "WARNING: stage $S is INCOMPLETE (chunk cap) - rerun to continue"
 done
 say "ALL" "index chains finished"

--- a/scripts/uae/texts_pipeline.sh
+++ b/scripts/uae/texts_pipeline.sh
@@ -57,14 +57,13 @@ TOTAL=$(cat "$SD/batch_count.txt" 2>/dev/null || echo 0)
 say "prepared $TOTAL batches"
 [ "$TOTAL" -eq 0 ] && { say "nothing to do"; exit 1; }
 
-$AWS lambda put-function-concurrency --function-name uae-fetch \
-     --reserved-concurrent-executions $CONC >/dev/null 2>&1 && say "reserved concurrency = $CONC"
-
-ls "$SD"/payloads/*.json | xargs -P 8 -I{} sh -c \
-  "aws --profile uae --region me-central-1 lambda invoke --function-name uae-fetch \
-   --invocation-type Event --cli-binary-format raw-in-base64-out \
-   --payload file://{} /dev/null >/dev/null 2>&1"
-say "all $TOTAL invocations queued"
+# Synchronous invokes: async events are silently dropped for this function
+# (accepted with 202, never executed, zero Errors and zero AsyncEventsDropped).
+# Concurrency is controlled here by xargs -P, not by reserved concurrency.
+mkdir -p "$SD/resp"
+say "running $TOTAL batches synchronously, $CONC at a time"
+ls "$SD"/payloads/*.json | xargs -P "$CONC" -n 1 "$(dirname "$0")/fetch_batch.sh"
+say "all $TOTAL batches attempted"
 
 for i in $(seq 1 400); do
     DONE=$($AWS s3 ls "s3://$B/texts/" 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
Follow-up to #2238, from actually running the Dubai harvest end to end. Three
bugs, all of which reported success while losing work.

## 1. Silent truncation

`index_chain.sh` stopped at a hardcoded 30-chunk cap and returned 0. The appeal
walk ended at page 3491 of 3876 and was logged `COMPLETE` — 12k judgments missing.
Caught only by comparing the total against what the portal advertises.

Cap is now `UAE_MAX_CHUNKS` (default 80); hitting it returns 2, logs `TRUNCATED`
and warns the stage is incomplete.

## 2. Async invocations never execute

`texts_pipeline.sh` queued 3114 batches with `--invocation-type Event`. All
accepted with 202, none ran: zero `Invocations`, zero `Errors`, zero
`AsyncEventsDropped` over 15 minutes. Now synchronous, like the index walk.

## 3. BSD xargs silently launches nothing

`xargs -I{}` with a long inline script fails with "command line cannot be
assembled, too long"; the pipeline logged "all 3114 batches attempted" one second
after starting. The invoke moved to `fetch_batch.sh`, which is also idempotent, so
re-running the pipeline skips completed batches.

Plus `UAE_STAGES`, so a single stage can be resumed. A finished stage saves no
resume state, so a blanket re-run would have re-walked all 1356 pages of cassation.

## State

Index complete: **155,686 judgments** (cassation 40,516; appeal 115,170). Text
fetch running at ~13 docs/s with zero failures. First instance deliberately out of
scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three issues in the Dubai harvest so we stop reporting success while dropping work. Index walks now flag truncation, text fetch runs synchronously, and batch fetching is idempotent.

- **Bug Fixes**
  - Index walk no longer silently truncates: uses `UAE_MAX_CHUNKS` (default 80), returns exit code 2, and logs TRUNCATED; the caller warns the stage is incomplete.
  - Text pipeline switches from async Lambda events (accepted with 202 but never executed) to synchronous invokes; concurrency is controlled via `xargs -P`.
  - Avoids BSD `xargs -I{}` command-length failure by moving the invoke into `fetch_batch.sh`.

- **New Features**
  - `fetch_batch.sh` is idempotent, so reruns skip completed batches.
  - `UAE_STAGES` lets you run or resume specific stages; `UAE_DELAY` controls pacing.

<sup>Written for commit 53a0cd52fcee1f8f3d1fcc7e84afbfd07bce6b49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

