### PR TITLE
fix(uae): extract the judgment, not the whole page

### DIFF
--- a/scripts/uae/README.md
+++ b/scripts/uae/README.md
@@ -98,6 +98,19 @@ polling status returns the previous "Successful" and you end up testing stale co
 `28 Jan 2014`; `build_dubai_jsonl.py` handles Arabic, Levantine and English month
 names plus Arabic-Indic digits.
 
+**The text extractor must anchor on `ut_verdict`, case-sensitively.** The judgment body
+lives in `<div class="ut_verdict">`; `ut_VerdictWeb` is the small parties block and appears
+*earlier* in the page, so a case-insensitive match silently returns ~150 characters instead
+of the judgment. The original greedy `<div class="...content...">(.*)</div>` ran to the last
+`</div>` on the page and swallowed the site nav and footer — **~3.7k identical characters per
+document, 29% of the corpus**, which is harmless for a citation graph and ruinous for a
+vector index. If you change this function, check the output length distribution, not just
+that it returned something.
+
+**Delete the invoke output file before every `lambda invoke`.** A failed invoke leaves the
+previous response in place, and it reads exactly like a fresh one — this produced two
+false "the fix doesn't work" diagnoses in a row.
+
 ## Legal note
 
 Dubai Courts' terms of use prohibit reproducing the service in whole or in part

--- a/scripts/uae/index_chain.sh
+++ b/scripts/uae/index_chain.sh
@@ -54,9 +54,20 @@ print('ok=%s rows=%s last_page=%s stopped_early=%s err=%s%s' % (
     d.get('err'), d.get('errorMessage','')))
 " 2>&1)
         say "$S" "chunk $n returned: $summary"
-        if ! $AWS s3 ls "s3://$B/$ck" >/dev/null 2>&1; then
-            say "$S" "chunk $n wrote no object - aborting chain"; return 1
-        fi
+        # a chunk can fail on a transient network error; retry it before giving up
+        local tries=1
+        while ! $AWS s3 ls "s3://$B/$ck" >/dev/null 2>&1; do
+            if [ $tries -ge 4 ]; then
+                say "$S" "chunk $n wrote no object after $tries tries - aborting chain"; return 1
+            fi
+            say "$S" "chunk $n wrote no object - retry $tries in 120s"
+            sleep 120
+            rm -f "$out"
+            $AWS lambda invoke --function-name uae-fetch \
+                 --cli-read-timeout 0 --cli-connect-timeout 60 \
+                 --cli-binary-format raw-in-base64-out --payload "$pay" "$out" >/dev/null 2>&1
+            tries=$((tries+1))
+        done
         local sz=$($AWS s3 ls "s3://$B/$ck" | awk '{print $3}')
         say "$S" "chunk $n stored (${sz} bytes)"
         sleep 60   # COOLDOWN between chunks, be gentle with the portal

--- a/scripts/uae/lambda/uae_fetch.py
+++ b/scripts/uae/lambda/uae_fetch.py
@@ -95,11 +95,46 @@ VERDICT_URL = ("https://www.dc.gov.ae/PublicServices/VerdictPreview.aspx?"
                "lang=&DecisionNumber=%(decision_no)s&OpenedLitigationStage=%(stage)s")
 
 
+# The judgment always opens with the Basmala; everything before it is site
+# navigation, and everything from the loading widget on is the page footer.
+# The old greedy `<div class="...content...">(.*)</div>` swallowed both — about
+# 3.7k characters of identical chrome per document, ~29% of the corpus.
+BASMALA = "بِسْمِ"
+FOOTER = "جاري التحميل"
+
+
+def _strip_chrome(t):
+    i = t.find(BASMALA)
+    if i == -1:
+        i = t.find("باسم صاحب السمو")
+    if 0 < i < 8000:
+        t = t[i:]
+    j = t.rfind(FOOTER)
+    if j > 500:
+        t = t[:j]
+    return t.strip()
+
+
 def _text(doc):
+    """Judgment text from the ut_verdict container.
+
+    Case-SENSITIVE on the class: 'ut_VerdictWeb' is the small parties block and
+    appears earlier in the page. The old greedy
+    `<div class="...content...">(.*)</div>` swallowed the site nav and footer -
+    about 3.7k characters of identical chrome per document, ~29% of the corpus.
+    """
     t = re.sub(r"(?is)<(script|style)[^>]*>.*?</\1>", " ", doc)
-    m = re.search(r'(?is)<div[^>]*class="[^"]*content[^"]*"[^>]*>(.*)</div>', t)
-    if m and len(m.group(1)) > 500:
-        t = m.group(1)
+    m = re.search(r'<div[^>]*class="[^"]*ut_verdict[\s"]', t)
+    if m:
+        start = t.find(">", m.start()) + 1
+        depth, end = 1, len(t)
+        for mm in re.finditer(r"<(/?)div\b", t[start:]):
+            depth += 1 if not mm.group(1) else -1
+            if depth == 0:
+                end = start + mm.start()
+                break
+        if end - start > 500:
+            t = t[start:end]
     t = re.sub(r"(?i)<br\s*/?>", "\n", t)
     t = re.sub(r"(?i)</(p|div|tr|li|h[1-6])>", "\n", t)
     t = re.sub(r"(?s)<[^>]+>", " ", t)
@@ -109,9 +144,7 @@ def _text(doc):
     t = t.replace("\x00", "").replace("\x01", " ").replace("\x02", " ")
     t = re.sub(r"[ \t]+", " ", t)
     t = re.sub(r"\n\s*\n+", "\n\n", t)
-    return t.strip()
-
-
+    return _strip_chrome(t.strip())
 
 
 def _dump_cookies(cj):
@@ -191,6 +224,18 @@ def lambda_handler(event, context):
             return _read(r)
 
     resumed_at = None
+
+    def _attempt(fn, tries=4):
+        """Network calls here face abrupt TLS EOFs; one must not kill a chunk."""
+        last = None
+        for a in range(tries):
+            try:
+                return fn()
+            except Exception as e:  # noqa: BLE001
+                last = e
+                time.sleep(5 * (a + 1) ** 2)
+        raise last
+
     try:
         if event.get("resume_state_key"):
             st = _s3_get(event["resume_state_key"])
@@ -201,16 +246,18 @@ def lambda_handler(event, context):
             fields["__EVENTTARGET"] = st["next_target"][1]
             fields["__EVENTARGUMENT"] = ""
             fields["__AJAX"] = "1440,3200,%s,2400,300,0,0,700,2450," % st["next_target"][0]
-            raw = post(fields)
+            raw = _attempt(lambda: post(fields))
             inner = _unescape_partial(raw)
             view = (inner + "\n" + raw) if inner else raw
         else:
-            with op.open(LIST_URL, timeout=timeout) as r:
-                doc = _read(r)
+            def _fresh():
+                with op.open(LIST_URL, timeout=timeout) as r:
+                    return _read(r)
+            doc = _attempt(_fresh)
             f = _hidden(doc)
             f.update(filters)
             f[P + "wtUT_SearchButton"] = "بحث"
-            view = post(f)
+            view = _attempt(lambda: post(f))
     except Exception as e:  # noqa: BLE001
         return {"ok": False, "phase": "search/resume",
                 "err": "%s: %s" % (type(e).__name__, e)}


### PR DESCRIPTION
Found by re-checking the corpus after it was already loaded and reported clean.

## The bug

`_text()` matched `<div class="...content...">(.*)</div>` greedily, so it ran to the last
`</div>` on the page and took the site chrome with it: **~2 900 chars of navigation menu
before every judgment and 834 of footer after it, byte-identical in all 436 763 rows** —
29% of the corpus.

Every load metric read perfect at the time: 0 missing dates, 0 thin texts, distinct hashes
equal to row count, counts matching the index exactly. Those check presence, not usability.
Harmless for a citation graph; ruinous for a vector index, where an identical 3.7k-char
blanket in every embedding pulls unrelated documents together.

## The fix

Take `<div class="ut_verdict">` by counting div depth. The class test is **case-sensitive on
purpose**: `ut_VerdictWeb` is the parties block and appears earlier in the page, so an
`(?i)` match silently returns ~150 characters. `_strip_chrome` then trims on content anchors
(the Basmala that opens every judgment, the loading widget that starts the footer), so a
layout change degrades rather than corrupts.

Verified: 8226 / 16455 / 7196 chars on three judgments across all three instances, no nav,
no footer, text starting with real judgment language.

Also `index_chain.sh`: a chunk that writes no object is retried up to 4 times, 120 s apart,
before the chain aborts. One TLS `EOF in violation of protocol` had killed a walk that then
idled 2.5 h; with the retry a later identical error cost nothing.

## Already-loaded data

Cleaned in place on prod with anchored cuts, batched 25k rows with COMMIT, `content_sha256`
recomputed in the same statement:

| | before | after |
|---|---:|---:|
| avg chars / judgment | 13 057 | 9 297 |
| Dubai text volume | 5.5 GB | 3.87 GB |
| rows with nav / footer | 436 763 | 0 |
| table size | 4 499 MB | 3 682 MB (post VACUUM FULL) |

20 000-row sample after: 0 hash mismatches, 0 footer remnants, 100% starting with the
Basmala, Arabic FTS still served by `idx_ae_fts_ar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the UAE extractor to capture only the judgment body and strip site chrome, removing identical nav/footer text that skewed embeddings. Adds retry logic to the indexing chain to avoid aborts on transient TLS errors.

- **Bug Fixes**
  - Extract from `<div class="ut_verdict">` by counting div depth; class match is case-sensitive to avoid `ut_VerdictWeb`.
  - Trim navigation/footer via `_strip_chrome` using content anchors (Basmala start, loading widget footer) for resilient output.
  - `index_chain.sh`: retry chunks up to 4 times (120s delay) when no S3 object is written; clear stale Lambda output before re-invoking. README updated with these safeguards.

<sup>Written for commit aebd568f6640d772549aaee7f0ee4ea236761d79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

