### PR TITLE
fix(platform): point MCP setup docs at /api/v2/mcp with a syntax that parses

### DIFF
--- a/mcp_backend/src/api/curated-mcp-tools.ts
+++ b/mcp_backend/src/api/curated-mcp-tools.ts
@@ -10,10 +10,18 @@
  *   • /api/v2/mcp  (Streamable HTTP, buildMcpServerV2)
  *   • /sse         (legacy SSE transport, MCPSSEServer)
  *
+ * The two transports do NOT advertise the same number of tools. /sse lists local
+ * handlers only (ToolRegistry.getLocalToolDefinitions), so the proxied openreyestr_*
+ * entries below are silently absent there; /api/v2/mcp resolves them through
+ * getAllToolDefinitions and advertises the full Set. Both filter by this whitelist,
+ * so neither can ever exceed it.
+ *
  * IMPORTANT: keep this in sync with the actual handler names registered in
- * factories/tool-services.ts. Every name here must resolve to a LOCAL handler so
- * it appears in ToolRegistry.getLocalToolDefinitions() (the SSE transport only
- * lists local tools).
+ * factories/tool-services.ts. A local name that does not resolve is logged as
+ * "Curated tools missing from local registry" rather than failing loudly.
+ *
+ * Do not restate the tool count in prose anywhere. This Set is the count; comments
+ * that hardcoded "15" drifted and stayed wrong for weeks.
  */
 export const V2_TOOL_NAMES = new Set<string>([
   // Legislation (6)

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -305,14 +305,17 @@ export function createMCPSSERoutes(deps: {
     return mcpServer;
   }
 
-  // ========================= MCP v2 (curated 15-tool subset) =========================
-  // v2 exposes a curated subset of 15 tools — 6 legislation + 9 court-decision (ЄДРСР) —
-  // instead of the ~112 low-level tools that v1 surfaces. A small, focused toolset keeps
-  // tool selection tractable for external MCP clients (Claude Code/Desktop) while still
-  // letting them call the real handlers directly. Execution, billing and cost-tracking are
-  // identical to v1 (buildMcpServer); only the exposed set differs.
-  // The whitelist is shared with the legacy /sse transport (MCPSSEServer) — see
-  // curated-mcp-tools.ts — so both endpoints advertise the same curated set.
+  // ========================= MCP v2 (curated tool subset) =========================
+  // v2 exposes a curated subset instead of the ~112 low-level tools that v1 surfaces. A
+  // small, focused toolset keeps tool selection tractable for external MCP clients (Claude
+  // Code/Desktop) while still letting them call the real handlers directly. Execution,
+  // billing and cost-tracking are identical to v1 (buildMcpServer); only the exposed set
+  // differs.
+  // The whitelist is V2_TOOL_NAMES in curated-mcp-tools.ts — that Set is the only source of
+  // truth for the count, so do not restate a number here; it has drifted before.
+  // The same whitelist is shared with the legacy /sse transport (MCPSSEServer), but the two
+  // endpoints do NOT advertise identical lists: /sse lists local tools only, while
+  // /api/v2/mcp also resolves the proxied openreyestr_* tools via getAllToolDefinitions.
 
   // Build an MCP Server exposing only the curated v2 subset. Reuses the fully-wired v1
   // builder (tools/list + tools/call with billing) with the whitelist applied.
@@ -610,7 +613,7 @@ export function createMCPSSERoutes(deps: {
   // POST /v1/mcp - JSON-RPC requests (initialize + tool calls). Stateful via Mcp-Session-Id.
   router.post('/v1/mcp', (async (req: DualAuthRequest, res: Response) => {
     try {
-      // Deprecated in favour of /api/v2/mcp (curated 15-tool subset). v1 still serves the
+      // Deprecated in favour of /api/v2/mcp (curated tool subset). v1 still serves the
       // full ~112-tool surface for backward compatibility; advertise the successor to clients.
       res.setHeader('Deprecation', 'true');
       res.setHeader('Link', '</api/v2/mcp>; rel="successor-version"');
@@ -707,7 +710,7 @@ export function createMCPSSERoutes(deps: {
 
   // ========================= /v2/mcp (Streamable HTTP, curated subset) =========================
   // Canonical transport. Same OAuth/session mechanics as /v1/mcp, but the wired MCP server
-  // exposes only the curated 15-tool subset (see buildMcpServerV2). Publicly reached at /api/v2/mcp.
+  // exposes only the curated subset (see buildMcpServerV2). Publicly reached at /api/v2/mcp.
   const MCP_V2_RESOURCE_METADATA_PATH = '/.well-known/oauth-protected-resource/api/v2/mcp';
 
   router.post('/v2/mcp', (async (req: DualAuthRequest, res: Response) => {
@@ -821,7 +824,7 @@ export function createMCPSSERoutes(deps: {
         'sse-standard': '/v1/sse',
         http: '/api/tools',
         'streamable-http-v1': '/api/v1/mcp',
-        // Canonical: curated 15-tool subset (6 legislation + 9 ЄДРСР).
+        // Canonical: curated subset (legislation + ЄДРСР + registries), see V2_TOOL_NAMES.
         'streamable-http-v2': '/api/v2/mcp',
       },
       tools: tools.map(t => ({

--- a/platform/src/pages/DashboardPage.tsx
+++ b/platform/src/pages/DashboardPage.tsx
@@ -46,9 +46,8 @@ export function DashboardPage() {
     </div>;
   }
 
-  const connectionCode = `claude mcp add secondlayer \\
-  --transport sse \\
-  --url https://mcp.legal.org.ua/v1/sse \\
+  const connectionCode = `claude mcp add --transport http secondlayer \\
+  https://mcp.legal.org.ua/api/v2/mcp \\
   --header "Authorization: Bearer ${data.firstKey || 'YOUR_API_KEY'}"`;
 
   return (

--- a/platform/src/pages/docs/ApiReferencePage.tsx
+++ b/platform/src/pages/docs/ApiReferencePage.tsx
@@ -74,16 +74,25 @@ Content-Type: application/json
         title="Batch Request"
       />
 
-      <h2>MCP SSE Endpoint</h2>
+      <h2>MCP Endpoint</h2>
       <div className="not-prose">
         <div className="flex items-center gap-2 mb-2">
-          <span className="text-xs font-bold px-2 py-0.5 rounded bg-blue-100 text-blue-700">GET</span>
-          <code className="text-sm">/v1/sse</code>
+          <span className="text-xs font-bold px-2 py-0.5 rounded bg-emerald-100 text-emerald-700">POST</span>
+          <code className="text-sm">/api/v2/mcp</code>
         </div>
       </div>
       <p>
-        SSE-ендпоінт для MCP-клієнтів (Claude Code, Claude Desktop). Використовує
-        стандартний MCP протокол через Server-Sent Events.
+        Основний ендпоінт для MCP-клієнтів (Claude Code, Claude Desktop, ChatGPT).
+        Транспорт Streamable HTTP, автентифікація за API-ключем або через OAuth
+        (RFC 9728 discovery на <code>/.well-known/oauth-protected-resource/api/v2/mcp</code>).
+        Віддає кураторський набір інструментів, а не весь реєстр.
+      </p>
+
+      <h3>Застарілі ендпоінти</h3>
+      <p>
+        <code>GET /v1/sse</code> — транспорт SSE, і <code>POST /api/v1/mcp</code> —
+        Streamable HTTP з повним набором інструментів. Обидва працюють, але нові
+        інтеграції слід робити на <code>/api/v2/mcp</code>.
       </p>
 
       <h2>Health Check</h2>

--- a/platform/src/pages/docs/IntegrationsPage.tsx
+++ b/platform/src/pages/docs/IntegrationsPage.tsx
@@ -8,7 +8,7 @@ export function IntegrationsPage() {
         SecondLayer підтримує три транспортні протоколи для інтеграції.
       </p>
 
-      <h2>MCP SSE (рекомендований)</h2>
+      <h2>MCP Streamable HTTP (рекомендований)</h2>
       <p>
         Найкращий варіант для MCP-сумісних клієнтів. Підтримує стрімінг,
         автоматичне виявлення інструментів та двосторонню комунікацію.
@@ -16,9 +16,8 @@ export function IntegrationsPage() {
 
       <h3>Claude Code</h3>
       <CodeBlock
-        code={`claude mcp add secondlayer \\
-  --transport sse \\
-  --url https://mcp.legal.org.ua/v1/sse \\
+        code={`claude mcp add --transport http secondlayer \\
+  https://mcp.legal.org.ua/api/v2/mcp \\
   --header "Authorization: Bearer YOUR_API_KEY"`}
         title="Terminal"
       />
@@ -28,7 +27,8 @@ export function IntegrationsPage() {
         code={`{
   "mcpServers": {
     "secondlayer": {
-      "url": "https://mcp.legal.org.ua/v1/sse",
+      "type": "http",
+      "url": "https://mcp.legal.org.ua/api/v2/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_KEY"
       }
@@ -37,6 +37,14 @@ export function IntegrationsPage() {
 }`}
         title="claude_desktop_config.json"
       />
+
+      <h2>MCP SSE (застарілий)</h2>
+      <p>
+        Транспорт <code>/v1/sse</code> залишається робочим для вже підключених клієнтів,
+        але нові інтеграції варто робити на Streamable HTTP. Клієнти, які спершу пробують
+        POST без <code>sessionId</code>, отримують на цьому ендпоінті 400 і частина з них
+        не робить fallback на SSE.
+      </p>
 
       <h2>REST API</h2>
       <p>

--- a/platform/src/pages/docs/IntroductionPage.tsx
+++ b/platform/src/pages/docs/IntroductionPage.tsx
@@ -26,15 +26,14 @@ export function IntroductionPage() {
         <li><strong>Claude Code</strong> — CLI від Anthropic</li>
         <li><strong>Claude Desktop</strong> — десктопний додаток</li>
         <li><strong>REST API</strong> — пряме HTTP-підключення</li>
-        <li><strong>SSE</strong> — Server-Sent Events для стрімінгу</li>
+        <li><strong>SSE</strong> — Server-Sent Events, застарілий транспорт</li>
       </ul>
 
       <h2>Швидкий старт</h2>
       <p>Підключіть Claude Code до SecondLayer за 30 секунд:</p>
       <CodeBlock
-        code={`claude mcp add secondlayer \\
-  --transport sse \\
-  --url https://mcp.legal.org.ua/v1/sse \\
+        code={`claude mcp add --transport http secondlayer \\
+  https://mcp.legal.org.ua/api/v2/mcp \\
   --header "Authorization: Bearer YOUR_API_KEY"`}
         title="Terminal"
       />

--- a/platform/src/pages/docs/QuickStartPage.tsx
+++ b/platform/src/pages/docs/QuickStartPage.tsx
@@ -16,12 +16,18 @@ export function QuickStartPage() {
 
       <h2>2. Claude Code (CLI)</h2>
       <CodeBlock
-        code={`claude mcp add secondlayer \\
-  --transport sse \\
-  --url https://mcp.legal.org.ua/v1/sse \\
+        code={`claude mcp add --transport http secondlayer \\
+  https://mcp.legal.org.ua/api/v2/mcp \\
   --header "Authorization: Bearer YOUR_API_KEY"`}
         title="Terminal"
       />
+      <p>
+        Крок 1 можна пропустити: якщо не передавати <code>--header</code>, Claude Code
+        авторизується через OAuth. Виконайте <code>/mcp</code>, оберіть secondlayer і
+        натисніть Authenticate, далі увійдіть своїм акаунтом у браузері. Зверніть увагу:
+        заданий <code>Authorization</code> вимикає OAuth, тож ці два способи
+        взаємовиключні.
+      </p>
       <p>Після додавання перезапустіть Claude Code. Тепер ви можете писати запити як:</p>
       <CodeBlock
         code={`> Знайди судові рішення про відшкодування моральної шкоди за 2024 рік
@@ -36,7 +42,8 @@ export function QuickStartPage() {
         code={`{
   "mcpServers": {
     "secondlayer": {
-      "url": "https://mcp.legal.org.ua/v1/sse",
+      "type": "http",
+      "url": "https://mcp.legal.org.ua/api/v2/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_KEY"
       }


### PR DESCRIPTION
## Why

`teosoph@gmail.com` reported MCP connection errors. His account was fine (9894 credits, \$481.41, `billing_enabled=t`, no 401s, no rate limits, successful tool calls throughout). The problem was our own onboarding snippet, served identically from the dashboard and all four docs pages:

```
claude mcp add secondlayer \
  --transport sse \
  --url https://mcp.legal.org.ua/v1/sse \
  --header "Authorization: Bearer YOUR_API_KEY"
```

Two independent defects:

1. **`--url` is not a flag.** Current Claude Code takes the URL as a positional argument. The command fails with `error: unknown option '--url'` before any network call. Verified against the installed CLI.
2. **It points at the legacy transport.** `POST /v1/sse` without a `sessionId` query param returns 400 `{"error":"Missing sessionId query parameter"}` (`mcp-sse-routes.ts:541`). Modern clients probe Streamable HTTP on the configured URL first; claude.ai tolerates the 400 and falls back to SSE, stricter clients treat it as the answer. Prod nginx logged 11 such 400s in one day.

## What changed

Every snippet now uses the form verified end to end against the live CLI and the live endpoint:

```
claude mcp add --transport http secondlayer \
  https://mcp.legal.org.ua/api/v2/mcp \
  --header "Authorization: Bearer YOUR_API_KEY"
```

Also documented the OAuth path, which skips the API-key step entirely, plus Claude Code's own constraint that a configured `Authorization` header disables OAuth fallback, so the two are mutually exclusive.

`ApiReferencePage` now documents `/api/v2/mcp` as the primary endpoint and demotes `/v1/sse` and `/api/v1/mcp` to a "deprecated" subsection rather than presenting SSE as the only MCP endpoint.

## Stale tool count

Backend comments called v2 a "curated 15-tool subset (6 legislation + 9 ЄДРСР)". `V2_TOOL_NAMES` actually holds **28** entries: 6 legislation, 9 ЄДРСР, `search_registry`, and 12 `openreyestr_*`. The 15 covered only the first two groups and has been wrong since the registry tools landed.

Rather than update the number so it can drift again, the comments now defer to the Set. Also recorded a real asymmetry that the old comment denied: `/sse` and `/api/v2/mcp` do **not** advertise the same list, because `/sse` lists local handlers only and the `openreyestr_*` entries are proxied.

## Verification

- `claude mcp add --transport http <name> <url> --header ...` accepted; the old `--url` form rejected. Test server entry created against the real endpoint, got `INVALID_API_KEY` for a junk token (so auth is reached and behaves), then removed.
- `POST /api/v2/mcp` returns 401 with correct RFC 9728 `www-authenticate` on both `legal.org.ua` and `mcp.legal.org.ua`; well-known metadata is self-consistent on each host.
- `platform`: `tsc --noEmit` exits 0.
- `mcp_backend` changes are comment-only, no behaviour change.

## Notes for the reviewer

- `mcp_backend` `tsc` reports 6 errors on this branch, all pre-existing on `main` and untouched here: 3 in `registry-catalog.ts` / `registry-search-tool.ts` (`array_contains_text` not in `MatchType`) and 3 in `core-loader.ts` (missing core-overlay modules, the known local-only false positives). Left alone to keep this PR scoped.
- The Claude Desktop JSON keeps its existing `url` + `headers` shape with `"type": "http"` added and the URL updated. I could not verify Desktop's config parser from here, so that one shape is unverified.
- Remaining `/v1/sse` references in `docs/**` and `mcp_backend/config-examples/**` are untouched. Happy to sweep them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MCP setup by switching docs and dashboard to Streamable HTTP at `/api/v2/mcp` with a `claude` command that actually parses, preventing connection errors. Also document OAuth login and mark `/v1/sse` and `/api/v1/mcp` as legacy.

- **Bug Fixes**
  - Replace invalid `--url` usage with a positional URL and `--transport http`; use `claude mcp add --transport http secondlayer https://mcp.legal.org.ua/api/v2/mcp --header "Authorization: Bearer YOUR_API_KEY"` across dashboard and docs.
  - Add OAuth path and note that setting an `Authorization` header disables OAuth fallback.

- **Refactors**
  - Clarify backend comments: avoid hardcoded tool counts and note SSE vs `/api/v2/mcp` advertise different tool lists; no runtime changes.

<sup>Written for commit c5ca4548da16bed5b4c51d12b3a0d7fcf743d6a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

