### PR TITLE
feat(uae): Federal Supreme Court corpus and federal-legislation amendment history

### DIFF
--- a/scripts/uae/README.md
+++ b/scripts/uae/README.md
@@ -9,11 +9,11 @@ Tools for building the `ae_court_decisions` corpus (DIFC, ADGM, Dubai Courts).
 | DIFC Courts | HTML | none | yes |
 | ADGM Courts | PDF | none | yes |
 | Dubai Courts | HTML | none | **no — UAE IP required** |
-| MOJ / Federal Supreme Court | HTML | none | no (blocks AWS ranges too) |
+| MOJ / Federal Supreme Court | JSON + PDF | none | yes |
 | ADJD (Abu Dhabi) | HTML | **UAE Pass** | not obtainable |
 
-DIFC and ADGM run anywhere. Dubai Courts geo-blocks non-UAE IPs, so requests go
-through a Lambda deployed in `me-central-1` (`lambda/uae_fetch.py`).
+DIFC, ADGM and the MOJ run anywhere. Dubai Courts geo-blocks non-UAE IPs, so its
+requests go through a Lambda deployed in `me-central-1` (`lambda/uae_fetch.py`).
 
 ## Layout
 
@@ -25,9 +25,11 @@ index_chain.sh         chained index walk per litigation stage
 texts_pipeline.sh      fan-out full-text fetch behind the index walk
 fetch_batch.sh         one text batch through the Lambda (idempotent)
 build_dubai_jsonl.py   join index metadata + texts   -> JSONL
+moj/                   Federal Supreme Court (see below)
 sql/01_create_table.sql
 sql/02_load_difc_adgm.sql
 sql/03_load_dubai.sql
+sql/06_load_moj_fsc.sql
 ```
 
 ## Usage
@@ -149,6 +151,52 @@ can always tell. OCR fixed all of it: 0 lost glyphs, 98.5% correct ligatures.
 default, so 8 workers × 8 threads on an 8-core box means 64 threads: load average 32,
 ~13 s/page, 16 documents in 2.5 h. One thread per worker gives 1.3 s/page. On a shared
 machine add `nice -n 19` and `ionice -c3` and leave cores for the app.
+
+## Federal Supreme Court (moj.gov.ae)
+
+```bash
+cd moj
+./fetch_index.sh index.json               # 4 469 records in one response
+CONC=8 ./download_pdfs.sh index.json pdf  # resumable, %PDF-checked
+python3 fetch_docx.py index.json txt      # the 3 records that are Word files
+python3 extract_all.py pdf txt report.jsonl
+./run_ocr.sh report.jsonl pdf txt         # only the documents the report flagged
+python3 build_jsonl.py index.json txt report.jsonl ae_moj_fsc.jsonl
+psql -f ../sql/06_load_moj_fsc.sql
+```
+
+**It was never geo-blocked — the endpoint just needed the right parameters.** The
+listing widget posts to `services/AjaxHandler.asmx/LoadCategorizeAssetsList`; the
+ASMX help page and `?WSDL` are disabled and any wrong parameter set answers a bare
+500, which reads exactly like a block. The working body is
+`{pageIndex, pageSize, languageId, languageCode, isArchived, thumbnailSizeFactor,
+excludeItems}` from `fi.listing.js` merged with `{keyword, openDataTypeID,
+categoryId, year, apiLink}` from `categorize-assets-listing.js` — note
+`openDataTypeID`, capital `ID`, unlike every neighbouring key. `openDataTypeID`
+450 is the Federal Supreme Court and **`pageSize: -1` returns all 4 469 records in
+one 7 MB response**, so there is no pagination to walk. `isArchived: true` returns
+the same set.
+
+**Two PDF generations, two different kinds of damage.** Newer files store
+logical-order Arabic but emit every lam-alef ligature reversed, as alef+lam:
+`الأربعاء` arrives as `األربعاء` and `جلال` as `جالل`. Orthography cannot separate
+that from the definite article `ال` — but geometry can, because **the decomposed
+alef carries zero width** while a real article's alef does not. `moj_text.py`
+drives the swap off the glyph boxes for that reason; a regex would eat every
+article in the corpus. Older files (roughly 2011-2015) instead store presentation
+forms plus kashidas the font maps to stray codepoints such as `ѧ`; NFKC and a
+script filter fix those completely.
+
+**Some documents carry the court's own bad OCR, and no decoder can save them.**
+Letters are dropped and kashidas come through as doubled letters (`قاتل` →
+`قاتاال`) — pdftotext and PyMuPDF agree, so it is the source. The rate of doubled
+Arabic letters separates the populations cleanly, 5-11 per 1000 Arabic characters
+for good documents against 20-170 for broken ones, so `extract_all.py` gates at 15
+and `run_ocr.sh` re-OCRs whatever fails. Genuine gemination is written with shadda,
+not by repeating the letter, which is why the measure works at all.
+
+**The mime type in the index lies.** Three records are declared
+`application/pdf` and link to `.docx`; go by the link extension.
 
 ## Legal note
 

--- a/scripts/uae/README.md
+++ b/scripts/uae/README.md
@@ -237,6 +237,43 @@ in particular list the amending act, its date and its PDF with an empty body, so
 count amendments and article changes separately — 427 amendments across 232 acts
 produced 1 313 article changes across 166 acts.
 
+## Judgment -> legislation citations
+
+```bash
+cd leg
+./run_citations.sh citations.jsonl        # streams 3.9 GB out of Postgres, ~25 min
+psql -f ../sql/10_load_citations.sql      # load + the two exact resolution passes
+psql -f ../sql/11_resolve_citations.sql   # the relaxed passes, re-runnable
+```
+
+**Every gap in the citation pattern has to be optional.** Judgments name an act as
+`<kind> رقم <n> لسنة <year>`, but the PDFs behind these texts glue words to numbers
+(`رقم5 لسنة2012`) and scatter parentheses (`رقم ( 38 )لسنة 2022`), and Arabic-Indic
+digits turn up. Acts cited by name alone (`قانون الإثبات`) are deliberately not
+matched: without a number and year they cannot be resolved without a name index,
+and guessing would put false edges in the graph.
+
+**Do not break ties by how specific the instrument type is.** That rule resolves
+everything and is confidently wrong: it turned the Arbitration Law 6/2018 into the
+supplementary budget decree 6/2018, an edge that looks entirely plausible in the
+data. The subject phrase the judgment gives beside the number (`بشأن التحكيم`) is
+what actually distinguishes them.
+
+**Use `word_similarity`, not `similarity`, to match that subject.** The subject is
+a short phrase and the title is long, so plain trigram similarity drowns the
+signal — on decree-law 33/2021 it scored the right act 0.095 against the wrong
+one's 0.057, while `word_similarity` gave 0.42 against 0.16. The pass also
+requires the winner to clear the runner-up by 40%, so an undecidable pair stays
+unresolved instead of being decided by noise.
+
+**A third of citations point at acts the corpus does not contain**, and that is
+the real ceiling, not the matcher: Civil Procedure Law 11/1992 alone accounts for
+29 322 of them. It was repealed and replaced by 42/2022, and the portal only
+serves what is current. Emirate-level Dubai legislation is the other large block.
+
+DIFC and ADGM contribute nothing here — they are English-language common-law
+courts and the extractor only runs over `language = 'ar'`.
+
 ## Legal note
 
 Dubai Courts' terms of use prohibit reproducing the service in whole or in part

--- a/scripts/uae/README.md
+++ b/scripts/uae/README.md
@@ -198,6 +198,45 @@ not by repeating the letter, which is why the measure works at all.
 **The mime type in the index lies.** Three records are declared
 `application/pdf` and link to `.docx`; go by the link extension.
 
+## Amendment history (uaelegislation.gov.ae)
+
+```bash
+cd leg
+python3 fetch_modifications.py ids.txt mods     # amendment pages, ~2.2 s/act
+python3 fetch_law_meta.py need_meta.txt lawmeta # dates+status for acts never amended
+python3 parse_modifications.py mods parsed
+python3 parse_modifications.py lawmeta parsedmeta
+python3 fetch_amendment_pdfs.py parsed/amendments.jsonl amendpdf
+psql -f ../sql/07_create_amendments.sql && psql -f ../sql/08_load_amendments.sql
+```
+
+**Cloudflare here scores the TLS fingerprint, not the IP.** Plain `curl` with a
+perfect browser header set gets 403 from a laptop, from prod and from the UAE
+Lambda alike, which looks exactly like an IP ban and is not one; `curl_cffi` with
+`impersonate` gets 200 from those same hosts. Profiles are scored individually
+and inconsistently — `chrome` and `safari17_0` do not always agree, and the same
+profile can pass then fail — so rotate profiles, warm a session on `/ar` first
+and reuse it.
+
+**The article-level history is not in the PDFs.** Only 2 of 2 862 downloaded
+acts carry an inline "this text is per the latest amendment" note; the real
+record is
+`POST /ar/legislations/<id>/modifications/list` with `{_token, year}`, where the
+token is scraped from the modifications page and must share that page's session.
+It returns, per amending act, the new text of every article touched *beside the
+text it replaced*. `/ar/materials/<id>/previous` gives the same per article.
+
+**An act with no amendments has no modifications page and answers 500.** That is
+the portal's way of saying "none", not a transient error — retrying it wastes the
+whole budget. Publication metadata for those acts is on the act's own page
+instead, which is why `fetch_law_meta.py` exists: without it, `status` and
+`issue_date` would only ever describe the 8% of acts that were amended.
+
+**Amendments are recorded even when the article bodies are not.** Repealed acts
+in particular list the amending act, its date and its PDF with an empty body, so
+count amendments and article changes separately — 427 amendments across 232 acts
+produced 1 313 article changes across 166 acts.
+
 ## Legal note
 
 Dubai Courts' terms of use prohibit reproducing the service in whole or in part

--- a/scripts/uae/leg/extract_citations.py
+++ b/scripts/uae/leg/extract_citations.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Find the federal acts each judgment cites.
+
+Emirati judgments name an act as <kind> رقم <number> لسنة <year>, and the shape
+is remarkably stable across courts.  What is not stable is the spacing: the PDFs
+these texts came from routinely glue words to numbers ("رقم5 لسنة2012") and
+scatter parentheses ("رقم ( 38 )لسنة 2022"), so every gap in the pattern has to
+be optional.  Arabic-Indic digits appear too.
+
+Where the citation is preceded by an article reference - "المادة 269 / 1 من ..."
+- the article numbers are captured with it, which is what lets a judgment be
+linked to a specific article rather than only to an act.
+
+Acts cited by name alone ("قانون الإثبات") are deliberately not matched: without
+a number and year they cannot be resolved without a name index, and guessing
+would put false edges in the graph.
+"""
+import hashlib
+import json
+import re
+import sys
+
+DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+
+# Ordered longest-first so "مرسوم بقانون اتحادي" wins over "قانون".
+KINDS = [
+    ("المرسوم بقانون اتحادي", "federal_decree_law"),
+    ("مرسوم بقانون اتحادي", "federal_decree_law"),
+    ("المرسوم بقانون", "decree_law"),
+    ("مرسوم بقانون", "decree_law"),
+    ("القانون الاتحادي", "federal_law"),
+    ("قانون اتحادي", "federal_law"),
+    ("المرسوم الاتحادي", "federal_decree"),
+    ("مرسوم اتحادي", "federal_decree"),
+    ("قرار مجلس الوزراء", "cabinet_resolution"),
+    ("قرار وزاري", "ministerial_resolution"),
+    ("اللائحة التنفيذية", "regulation"),
+    ("القانون", "law"),
+    ("قانون", "law"),
+    ("القرار", "resolution"),
+    ("قرار", "resolution"),
+]
+KIND_ALT = "|".join(re.escape(k) for k, _ in KINDS)
+KIND_LOOKUP = dict(KINDS)
+
+CITATION = re.compile(
+    r"(?P<kind>" + KIND_ALT + r")"
+    r"[^\S\n]{0,3}(?:\s*ال\w+)?"          # an adjective may sit between kind and رقم
+    r"\s*رقم\s*\(?\s*(?P<num>\d{1,4})\s*\)?"
+    r"\s*(?P<bis>مكرر)?"
+    r"\s*\)?\s*لسن[ةه]\s*\(?\s*(?P<year>\d{4})")
+
+# "المادة (5)", "المادتين 11، 12", "المواد 1 - 4" immediately before the act.
+ARTICLES = re.compile(r"(?:المواد|المادتين|المادتان|المادة|للمادة|بالمادة)"
+                      r"\s*\(?\s*([\d\s،,/\-\)\(و]{1,60})")
+ART_NUM = re.compile(r"\d{1,4}")
+
+
+def normalise(text):
+    return text.translate(DIGITS)
+
+
+def extract(doc_id, text):
+    """Yield one record per act cited, with any article numbers named beside it."""
+    text = normalise(text)
+    seen = {}
+    for seq, m in enumerate(CITATION.finditer(text)):
+        kind_ar = m.group("kind")
+        number = m.group("num")
+        year = int(m.group("year"))
+        if not 1970 <= year <= 2030:
+            continue
+        window = text[max(0, m.start() - 130):m.start()]
+        articles = []
+        am = None
+        for am in ARTICLES.finditer(window):
+            pass                      # the closest article reference is the last one
+        if am is not None and m.start() - (max(0, m.start() - 130) + am.end()) <= 12:
+            articles = ART_NUM.findall(am.group(1))[:8]
+        key = (KIND_LOOKUP[kind_ar], number, year)
+        rec = seen.get(key)
+        if rec is None:
+            raw = re.sub(r"\s+", " ",
+                         text[max(0, m.start() - 40):m.end() + 60]).strip()
+            seen[key] = {
+                "doc_id": doc_id,
+                "law_type": KIND_LOOKUP[kind_ar],
+                "kind_ar": kind_ar,
+                "law_number": number,
+                "law_year": year,
+                "articles": articles,
+                "mentions": 1,
+                "raw": raw,
+                "seq": seq,
+            }
+        else:
+            rec["mentions"] += 1
+            for a in articles:
+                if a not in rec["articles"]:
+                    rec["articles"].append(a)
+    for rec in seen.values():
+        rec["citation_id"] = "%s:%s" % (
+            rec["doc_id"],
+            hashlib.sha1(("%s|%s|%s" % (rec["law_type"], rec["law_number"],
+                                        rec["law_year"])).encode()).hexdigest()[:10])
+        yield rec
+
+
+if __name__ == "__main__":
+    # Ad-hoc use: a file of {"doc_id":..., "full_text":...} JSON lines.
+    for line in sys.stdin:
+        row = json.loads(line)
+        for rec in extract(row["doc_id"], row["full_text"] or ""):
+            print(json.dumps(rec, ensure_ascii=False))

--- a/scripts/uae/leg/fetch_amendment_pdfs.py
+++ b/scripts/uae/leg/fetch_amendment_pdfs.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Download the PDF of each amending act.
+
+The amendment list gives each one its own id under
+`/ar/constitution/modifications/<id>/download`.  These are the instruments
+themselves - worth holding alongside the parsed article changes, since the
+portal's own rendering is a summary of them.
+
+Same Cloudflare handling as fetch_modifications.py, and the same rule as the
+rest of this portal: a missing document answers 200 with an HTML shell, so a
+file counts as downloaded only if it starts with %PDF.
+"""
+import json
+import os
+import random
+import sys
+import time
+
+from curl_cffi import requests
+
+BASE = "https://uaelegislation.gov.ae"
+PROFILES = ["safari17_0", "chrome", "safari15_5", "chrome110"]
+_state = {"s": None, "n": 0}
+
+
+def session():
+    if _state["s"] is None:
+        s = requests.Session(impersonate=PROFILES[_state["n"] % len(PROFILES)])
+        _state["n"] += 1
+        try:
+            s.get(BASE + "/ar", timeout=90)
+        except Exception:  # noqa: BLE001
+            pass
+        _state["s"] = s
+    return _state["s"]
+
+
+def fetch(mod_id, dst, tries=4):
+    for attempt in range(tries):
+        try:
+            r = session().get("%s/ar/constitution/modifications/%d/download" % (BASE, mod_id),
+                              timeout=120)
+            if r.status_code == 200 and r.content[:4] == b"%PDF":
+                with open(dst, "wb") as fh:
+                    fh.write(r.content)
+                return True
+            if r.status_code == 200:
+                return False  # a shell, not a document - retrying will not help
+        except Exception:  # noqa: BLE001
+            pass
+        _state["s"] = None
+        time.sleep(2 + attempt * 2)
+    return False
+
+
+def main():
+    amendments_jsonl, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+    ids = sorted({json.loads(l).get("modification_id")
+                  for l in open(amendments_jsonl, encoding="utf-8")} - {None})
+    got = shell = 0
+    for mod_id in ids:
+        dst = os.path.join(out_dir, "%d.pdf" % mod_id)
+        if os.path.exists(dst) and os.path.getsize(dst) > 1000:
+            got += 1
+            continue
+        if fetch(mod_id, dst):
+            got += 1
+        else:
+            shell += 1
+            print("no document for %d" % mod_id, flush=True)
+        if (got + shell) % 50 == 0:
+            print("%d/%d done" % (got + shell, len(ids)), flush=True)
+        time.sleep(random.uniform(0.3, 0.7))
+    print("amendment PDFs: %d downloaded, %d unavailable, %d listed" % (got, shell, len(ids)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/leg/fetch_law_meta.py
+++ b/scripts/uae/leg/fetch_law_meta.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Fetch publication metadata for acts that have no amendment page.
+
+The gazette reference, the issue and effective dates and the in-force status sit
+on the act's own page as well, so the 90% of the corpus that was never amended -
+and therefore has no modifications page at all - can still be dated and given a
+status.  Without this the status column would only ever describe amended acts,
+which is the opposite of a representative sample.
+"""
+import gzip
+import json
+import os
+import random
+import re
+import sys
+import time
+
+from curl_cffi import requests
+
+BASE = "https://uaelegislation.gov.ae"
+PROFILES = ["safari17_0", "chrome", "safari15_5", "chrome110"]
+CARD = re.compile(
+    r'<div class="widget_card_v2">.*?<div class="name_">\s*<p>(.*?)</p>.*?<h4>(.*?)</h4>',
+    re.S)
+LAST_UPDATE = re.compile(r'التشريع وفقاً لآخر تحديث في\s*([^<]+)<')
+TAGS = re.compile(r"<[^>]+>")
+_state = {"s": None, "n": 0}
+
+
+def clean(s):
+    return re.sub(r"\s+", " ", TAGS.sub(" ", s or "")).strip()
+
+
+def session():
+    if _state["s"] is None:
+        s = requests.Session(impersonate=PROFILES[_state["n"] % len(PROFILES)])
+        _state["n"] += 1
+        try:
+            s.get(BASE + "/ar", timeout=90)
+        except Exception:  # noqa: BLE001
+            pass
+        _state["s"] = s
+    return _state["s"]
+
+
+def fetch(law_id, tries=5):
+    for attempt in range(tries):
+        try:
+            r = session().get("%s/ar/legislations/%d" % (BASE, law_id), timeout=90)
+            if r.status_code == 200:
+                upd = LAST_UPDATE.search(r.text)
+                return {"law_id": law_id,
+                        "meta": {clean(k): clean(v) for k, v in CARD.findall(r.text)},
+                        "last_update": clean(upd.group(1)) if upd else None,
+                        "lists": {}, "years": []}
+            if r.status_code == 404:
+                return {"law_id": law_id, "missing": True}
+        except Exception:  # noqa: BLE001
+            pass
+        _state["s"] = None
+        time.sleep(2 + attempt * 2)
+    return None
+
+
+def main():
+    ids_file, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+    ids = [int(x) for x in open(ids_file).read().split()]
+    done = failed = 0
+    for law_id in ids:
+        dst = os.path.join(out_dir, "%d.json.gz" % law_id)
+        if os.path.exists(dst) and os.path.getsize(dst) > 40:
+            continue
+        rec = fetch(law_id)
+        if rec is None:
+            failed += 1
+            print("FAIL %d" % law_id, flush=True)
+            continue
+        with gzip.open(dst, "wt", encoding="utf-8") as fh:
+            json.dump(rec, fh, ensure_ascii=False)
+        done += 1
+        if done % 50 == 0:
+            print("%d done, %d failed" % (done, failed), flush=True)
+        time.sleep(random.uniform(0.2, 0.5))
+    print("finished: %d written, %d failed" % (done, failed))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/leg/fetch_materials.py
+++ b/scripts/uae/leg/fetch_materials.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Harvest the article-level text of each act.
+
+`/ar/legislations/<id>/materials-ajax?page=N` returns the act split into
+articles as clean HTML - no OCR, correct ligatures, chapter headings intact.
+It is strictly better than the rasterised PDF text the corpus was built from,
+and it is the only route to per-article identifiers, which is what the amendment
+history keys on.
+
+`next` carries the following page, or null when the act is complete; a long act
+runs to several pages, so the walk follows it rather than assuming one.
+
+Cloudflare handling is the same as fetch_modifications.py: it scores the TLS
+handshake, so a browser-shaped one is required and profiles are rotated on
+refusal.
+"""
+import gzip
+import json
+import os
+import random
+import sys
+import time
+
+from curl_cffi import requests
+
+BASE = "https://uaelegislation.gov.ae"
+PROFILES = ["safari17_0", "chrome", "safari15_5", "chrome110"]
+MAX_PAGES = 60
+_state = {"s": None, "n": 0}
+
+
+def session():
+    if _state["s"] is None:
+        s = requests.Session(impersonate=PROFILES[_state["n"] % len(PROFILES)])
+        _state["n"] += 1
+        try:
+            s.get(BASE + "/ar", timeout=90)
+        except Exception:  # noqa: BLE001
+            pass
+        _state["s"] = s
+    return _state["s"]
+
+
+def fetch_page(law_id, page, tries=5):
+    for attempt in range(tries):
+        try:
+            r = session().get(
+                "%s/ar/legislations/%d/materials-ajax?page=%d" % (BASE, law_id, page),
+                timeout=90)
+            if r.status_code == 200:
+                return r.json()
+            if r.status_code in (404, 500):
+                return None
+        except Exception:  # noqa: BLE001
+            pass
+        _state["s"] = None
+        time.sleep(2 + attempt * 2)
+    raise RuntimeError("law %d page %d unreachable" % (law_id, page))
+
+
+def fetch_law(law_id):
+    pages, page = [], 1
+    while page <= MAX_PAGES:
+        data = fetch_page(law_id, page)
+        if data is None:
+            break
+        pages.append({"page": page,
+                      "index_list": data.get("index_list", ""),
+                      "html_data": data.get("html_data", "")})
+        if not data.get("next"):
+            break
+        page += 1
+        time.sleep(0.3)
+    return {"law_id": law_id, "pages": pages,
+            "truncated": page >= MAX_PAGES}
+
+
+def main():
+    ids_file, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+    ids = [int(x) for x in open(ids_file).read().split()]
+    done = empty = failed = 0
+    for law_id in ids:
+        dst = os.path.join(out_dir, "%d.json.gz" % law_id)
+        if os.path.exists(dst) and os.path.getsize(dst) > 40:
+            continue
+        try:
+            rec = fetch_law(law_id)
+        except RuntimeError as exc:
+            failed += 1
+            print("FAIL %s" % exc, flush=True)
+            continue
+        if not rec["pages"]:
+            empty += 1
+        if rec["truncated"]:
+            print("TRUNCATED at %d pages: law %d" % (MAX_PAGES, law_id), flush=True)
+        with gzip.open(dst, "wt", encoding="utf-8") as fh:
+            json.dump(rec, fh, ensure_ascii=False)
+        done += 1
+        if done % 50 == 0:
+            print("%d done, %d without articles, %d failed" % (done, empty, failed),
+                  flush=True)
+        time.sleep(random.uniform(0.2, 0.5))
+    print("finished: %d written, %d without articles, %d failed" % (done, empty, failed))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/leg/fetch_modifications.py
+++ b/scripts/uae/leg/fetch_modifications.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Harvest the amendment history of each UAE federal act.
+
+The portal keeps a full per-article history that the downloadable PDFs do not
+show: `/ar/legislations/<id>/modifications` carries the act's dates, gazette
+reference and status, and `POST /ar/legislations/<id>/modifications/list`
+returns, per year, every amending act together with the *new and the previous
+text of each article it touched*.  That pair is what makes "what changed, and
+when" answerable rather than merely assertable.
+
+Cloudflare fronts the site and scores each request on its TLS fingerprint, not
+on the IP: a plain curl gets 403 from anywhere, while a browser-shaped handshake
+gets 200 from the same machine.  Hence curl_cffi with impersonation, a session
+per law so the CSRF token and its cookie agree, and a rotation of profiles on
+refusal.
+
+Raw HTML is what gets stored.  Parsing is a separate step so that a parser fix
+never costs another pass over the site.
+"""
+import gzip
+import json
+import os
+import random
+import re
+import sys
+import time
+
+from curl_cffi import requests
+
+BASE = "https://uaelegislation.gov.ae"
+PROFILES = ["safari17_0", "chrome", "safari15_5", "chrome110"]
+CARD = re.compile(
+    r'<div class="widget_card_v2">.*?<div class="name_">\s*<p>(.*?)</p>.*?<h4>(.*?)</h4>',
+    re.S)
+YEAR = re.compile(r'name="year"\s+value="(\d{4})"')
+TOKEN = re.compile(r'_token:\s*"([^"]+)"')
+LAST_UPDATE = re.compile(r'التشريع وفقاً لآخر تحديث في\s*([^<]+)<')
+TAGS = re.compile(r"<[^>]+>")
+
+
+def clean(s):
+    return re.sub(r"\s+", " ", TAGS.sub(" ", s)).strip()
+
+
+_session = {"s": None, "profile": 0}
+
+
+def _new_session():
+    """A warmed session: the homepage hands out the cookies the rest relies on."""
+    profile = PROFILES[_session["profile"] % len(PROFILES)]
+    _session["profile"] += 1
+    s = requests.Session(impersonate=profile)
+    try:
+        s.get(BASE + "/ar", timeout=90)
+    except Exception:  # noqa: BLE001
+        pass
+    _session["s"] = s
+    return s
+
+
+def fetch_law(law_id, tries=5):
+    """Return the act's header metadata plus one HTML blob per amendment year.
+
+    An act with no amendments has no modifications page at all and the portal
+    answers 500 for it, so that status is an answer, not a failure to retry.
+    """
+    last_status = None
+    for attempt in range(tries):
+        session = _session["s"] or _new_session()
+        try:
+            page = session.get("%s/ar/legislations/%d/modifications" % (BASE, law_id),
+                               timeout=90)
+        except Exception:  # noqa: BLE001 - transport hiccups are expected here
+            _new_session()
+            time.sleep(2 + attempt)
+            continue
+        last_status = page.status_code
+        if page.status_code == 404:
+            return {"law_id": law_id, "missing": True}
+        if page.status_code == 500:
+            return {"law_id": law_id, "no_modifications": True}
+        if page.status_code != 200:
+            _new_session()
+            time.sleep(2 + attempt * 2)
+            continue
+
+        html = page.text
+        meta = {clean(k): clean(v) for k, v in CARD.findall(html)}
+        upd = LAST_UPDATE.search(html)
+        years = sorted(set(YEAR.findall(html)))
+        token = TOKEN.search(html)
+
+        lists = {}
+        if token and years:
+            for year in years:
+                for sub in range(3):
+                    try:
+                        resp = session.post(
+                            "%s/ar/legislations/%d/modifications/list" % (BASE, law_id),
+                            json={"_token": token.group(1), "year": year}, timeout=90)
+                        if resp.status_code == 200:
+                            lists[year] = resp.json().get("html", "")
+                            break
+                    except Exception:  # noqa: BLE001
+                        pass
+                    time.sleep(1.5 * (sub + 1))
+        return {
+            "law_id": law_id,
+            "meta": meta,
+            "last_update": clean(upd.group(1)) if upd else None,
+            "years": years,
+            "lists": lists,
+        }
+    return {"law_id": law_id, "error": "http %s" % last_status}
+
+
+def main():
+    ids_file, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+    ids = [int(x) for x in open(ids_file).read().split()]
+    done = failed = 0
+    for law_id in ids:
+        dst = os.path.join(out_dir, "%d.json.gz" % law_id)
+        if os.path.exists(dst) and os.path.getsize(dst) > 40:
+            continue
+        rec = fetch_law(law_id)
+        if rec.get("error"):
+            failed += 1
+            print("FAIL %d %s" % (law_id, rec["error"]), flush=True)
+            continue
+        with gzip.open(dst, "wt", encoding="utf-8") as fh:
+            json.dump(rec, fh, ensure_ascii=False)
+        done += 1
+        if done % 25 == 0:
+            print("%d done, %d failed" % (done, failed), flush=True)
+        time.sleep(random.uniform(0.3, 0.8))
+    print("finished: %d written, %d failed" % (done, failed))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/leg/parse_materials.py
+++ b/scripts/uae/leg/parse_materials.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Turn harvested article pages into one JSONL row per article.
+
+Chapter headings sit between the article blocks rather than inside them, so the
+current heading is carried forward as the blocks are walked; that is the only
+way to attribute an article to its chapter here.
+
+An article whose title carries the "previous texts" tooltip has been amended at
+some point, which gives a cheap cross-check against the amendment tables built
+from the modifications endpoint.
+"""
+import glob
+import gzip
+import hashlib
+import json
+import os
+import re
+import sys
+
+from bs4 import BeautifulSoup
+
+ARTICLE_NO = re.compile(r"المادة\s*\(?\s*([\d/\-]+)")
+DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+
+
+def clean(node):
+    text = node.get_text("\n") if node is not None else ""
+    text = re.sub(r"[ \t]+", " ", text)
+    return re.sub(r"\n\s*\n+", "\n\n", text).strip()
+
+
+def parse_law(rec, out):
+    law_id = rec["law_id"]
+    seq = 0
+    chapter = None
+    written = 0
+    for page in rec.get("pages", []):
+        soup = BeautifulSoup(page.get("html_data", ""), "lxml")
+        root = soup.body or soup
+        for node in root.descendants:
+            if getattr(node, "name", None) != "div":
+                continue
+            classes = node.get("class") or []
+            if "content_" not in classes:
+                continue
+            # the nearest preceding gold heading is this article's chapter
+            prev = node.find_previous(
+                lambda t: t.name == "h4" and "gold_color" in (t.get("class") or []))
+            if prev is not None:
+                chapter = re.sub(r"\s+", " ", prev.get_text(" ")).strip()
+            title = node.select_one(".c_title h4")
+            label = None
+            if title is not None:
+                # the "previous texts" tooltip lives inside the heading and
+                # would otherwise be read as part of the article's title
+                head = BeautifulSoup(str(title), "lxml")
+                for tip in head.select("[data-fancybox-material], .tooltip_holder"):
+                    tip.decompose()
+                label = re.sub(r"\s+", " ", head.get_text(" ")).strip() or None
+            body = node.select_one(".text_area")
+            text = clean(body)
+            if not text:
+                continue
+            material_id = (node.get("id") or "").replace("item", "") or None
+            art = ARTICLE_NO.search((label or "").translate(DIGITS))
+            out.write(json.dumps({
+                "article_id": "uaeleg:%d:%s" % (law_id, material_id or seq),
+                "law_id": law_id,
+                "material_id": int(material_id) if material_id and material_id.isdigit() else None,
+                "seq": seq,
+                "chapter": chapter,
+                "article_label": label,
+                "article_no": art.group(1) if art else None,
+                "text": text,
+                "has_previous": bool(node.select_one("[data-fancybox-material]")),
+                "content_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            }, ensure_ascii=False) + "\n")
+            seq += 1
+            written += 1
+    return written
+
+
+def main():
+    src, out_path = sys.argv[1], sys.argv[2]
+    laws = amended = total = 0
+    with open(out_path, "w", encoding="utf-8") as out:
+        for path in sorted(glob.glob(os.path.join(src, "*.json.gz")),
+                           key=lambda p: int(os.path.basename(p).split(".")[0])):
+            with gzip.open(path, "rt", encoding="utf-8") as fh:
+                rec = json.load(fh)
+            n = parse_law(rec, out)
+            if n:
+                laws += 1
+                total += n
+    with open(out_path, encoding="utf-8") as fh:
+        amended = sum(1 for line in fh if json.loads(line)["has_previous"])
+    print("articles %d across %d acts, %d carry previous versions" % (total, laws, amended))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/leg/parse_modifications.py
+++ b/scripts/uae/leg/parse_modifications.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Turn harvested amendment pages into three JSONL streams.
+
+  laws.jsonl       one row per act: gazette reference, dates, status
+  amendments.jsonl one row per amending act, with its date and PDF
+  changes.jsonl    one row per article touched, holding the new text and the
+                   text it replaced - the pair that answers "how did it change"
+
+Dates arrive as Arabic month names ("08 مايو 2016") and Arabic-Indic digits
+appear in article labels, so both are normalised here rather than downstream.
+"""
+import datetime
+import glob
+import gzip
+import hashlib
+import json
+import os
+import re
+import sys
+
+from bs4 import BeautifulSoup
+
+MONTHS = {
+    "يناير": 1, "فبراير": 2, "مارس": 3, "أبريل": 4, "ابريل": 4, "مايو": 5,
+    "يونيو": 6, "يوليو": 7, "أغسطس": 8, "اغسطس": 8, "سبتمبر": 9,
+    "أكتوبر": 10, "اكتوبر": 10, "نوفمبر": 11, "ديسمبر": 12,
+}
+DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+ARTICLE_NO = re.compile(r"المادة\s*\(?\s*([\d/\-]+)")
+MOD_ID = re.compile(r"/modifications/(\d+)/download")
+STATUS = {"ساري": "in_force", "ملغي": "repealed", "ملغى": "repealed",
+          "معدل": "amended", "موقوف": "suspended"}
+
+
+def norm(s):
+    return re.sub(r"\s+", " ", (s or "")).translate(DIGITS).strip()
+
+
+def parse_date(raw):
+    raw = norm(raw)
+    m = re.search(r"(\d{1,2})\s+(\S+)\s+(\d{4})", raw)
+    if not m or m.group(2) not in MONTHS:
+        return None
+    try:
+        return datetime.date(int(m.group(3)), MONTHS[m.group(2)],
+                             int(m.group(1))).isoformat()
+    except ValueError:
+        return None
+
+
+def sha(text):
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def block_text(node, drop=()):
+    """Visible text of a node, minus whole subtrees we account for separately."""
+    clone = BeautifulSoup(str(node), "lxml")
+    for sel in drop:
+        for tag in clone.select(sel):
+            tag.decompose()
+    return re.sub(r"\n{3,}", "\n\n",
+                  re.sub(r"[ \t]+", " ", clone.get_text("\n"))).strip()
+
+
+def parse_law(rec, laws, amendments, changes):
+    law_id = rec["law_id"]
+    meta = rec.get("meta") or {}
+    status_ar = norm(meta.get("حالة التشريع"))
+    laws.write(json.dumps({
+        "law_id": law_id,
+        "issue_date": parse_date(meta.get("تاريخ إصدار التشريع")),
+        "effective_date": parse_date(meta.get("تاريخ نفاذ التشريع")),
+        "gazette_date": parse_date(meta.get("تاريخ الجريدة الرسمية")),
+        "gazette_number": norm(meta.get("عدد الجريدة الرسمية")) or None,
+        "status_ar": status_ar or None,
+        "status": STATUS.get(status_ar),
+        "last_update": parse_date(rec.get("last_update")),
+        "amendments_declared": norm(meta.get("تعديلات التشريع")) or None,
+        "no_modifications": bool(rec.get("no_modifications")),
+    }, ensure_ascii=False) + "\n")
+
+    n_amend = n_change = 0
+    for year, html in sorted((rec.get("lists") or {}).items()):
+        soup = BeautifulSoup(html, "lxml")
+        for item in soup.select(".law_modification_item"):
+            head = item.select_one(".law_modification_head")
+            date_raw = norm(head.select_one(".date_").get_text(" ")) if head and head.select_one(".date_") else ""
+            title = norm(head.select_one(".name_").get_text(" ")) if head and head.select_one(".name_") else None
+            link = item.select_one('a[href*="/modifications/"]')
+            href = link.get("href", "") if link else ""
+            mod = MOD_ID.search(href)
+            mod_id = int(mod.group(1)) if mod else None
+            amendment_id = "uaeleg:%d:%s" % (law_id, mod_id if mod_id else "%s-%d" % (year, n_amend))
+
+            article_rows = []
+            for seq, area in enumerate(item.select(".law_modification_body .item_area")):
+                text_area = area.select_one(".text_area")
+                if text_area is None:
+                    continue
+                heading = text_area.select_one("h4")
+                label = norm(heading.get_text(" ")) if heading else None
+                new_text = block_text(text_area, drop=("h4",))
+                previous = [
+                    {"label": norm(prev.select_one(".name_").get_text(" ")) if prev.select_one(".name_") else None,
+                     "text": block_text(prev.select_one(".text_")) if prev.select_one(".text_") else None}
+                    for prev in area.select(".inner_modification_wrapper .i_m_item")
+                ]
+                art = ARTICLE_NO.search(label or "")
+                prev_text = previous[0]["text"] if previous else None
+                article_rows.append({
+                    "change_id": "%s:%d" % (amendment_id, seq),
+                    "amendment_id": amendment_id,
+                    "law_id": law_id,
+                    "seq": seq,
+                    "article_label": label,
+                    "article_no": art.group(1) if art else None,
+                    "new_text": new_text or None,
+                    "previous_text": prev_text,
+                    "new_sha256": sha(new_text) if new_text else None,
+                    "previous_sha256": sha(prev_text) if prev_text else None,
+                    "previous_versions": len(previous),
+                    "text_changed": bool(new_text and prev_text and new_text != prev_text),
+                })
+
+            amendments.write(json.dumps({
+                "amendment_id": amendment_id,
+                "law_id": law_id,
+                "modification_id": mod_id,
+                "amend_date": parse_date(date_raw),
+                "amend_year": int(year),
+                "amend_date_raw": date_raw or None,
+                "amending_title": title,
+                "amending_pdf_url": href or None,
+                "articles_changed": len(article_rows),
+            }, ensure_ascii=False) + "\n")
+            n_amend += 1
+            for row in article_rows:
+                changes.write(json.dumps(row, ensure_ascii=False) + "\n")
+                n_change += 1
+    return n_amend, n_change
+
+
+def main():
+    src, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+    totals = [0, 0, 0]
+    with open(os.path.join(out_dir, "laws.jsonl"), "w", encoding="utf-8") as laws, \
+         open(os.path.join(out_dir, "amendments.jsonl"), "w", encoding="utf-8") as amendments, \
+         open(os.path.join(out_dir, "changes.jsonl"), "w", encoding="utf-8") as changes:
+        for path in sorted(glob.glob(os.path.join(src, "*.json.gz")),
+                           key=lambda p: int(os.path.basename(p).split(".")[0])):
+            with gzip.open(path, "rt", encoding="utf-8") as fh:
+                rec = json.load(fh)
+            if rec.get("missing"):
+                continue
+            a, c = parse_law(rec, laws, amendments, changes)
+            totals[0] += 1
+            totals[1] += a
+            totals[2] += c
+    print("laws %d, amendments %d, article changes %d" % tuple(totals))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uae/leg/run_citations.sh
+++ b/scripts/uae/leg/run_citations.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Extract legislation citations from every Arabic judgment.
+#
+# The corpus is ~3.9 GB of text, so it is streamed straight out of Postgres into
+# the extractor rather than staged on disk: COPY TO STDOUT on one end, JSONL on
+# the other, nothing in between.
+set -euo pipefail
+
+OUT="${1:-citations.jsonl}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PGPW=$(grep -E "^POSTGRES_PASSWORD=" ~/SecondLayer/deployment/.env.prod | head -1 | cut -d= -f2- | tr -d "\"'")
+
+docker exec -i -e PGPASSWORD="$PGPW" secondlayer-postgres-prod \
+  psql -U secondlayer -d secondlayer_prod -v ON_ERROR_STOP=1 -c \
+  "\copy (SELECT json_build_object('doc_id', doc_id, 'full_text', full_text) \
+          FROM ae_court_decisions \
+          WHERE language = 'ar' AND full_text IS NOT NULL) \
+   TO STDOUT WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')" \
+  | python3 "$HERE/extract_citations.py" > "$OUT"
+
+echo "citations: $(wc -l < "$OUT")"
+echo "documents citing: $(cut -d'"' -f4 "$OUT" | sort -u | wc -l)"

--- a/scripts/uae/moj/build_jsonl.py
+++ b/scripts/uae/moj/build_jsonl.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Join the index metadata with the extracted text into loadable JSONL.
+
+Emits one line per judgment matching ae_court_decisions, so the same loader
+shape as the Dubai and legislation corpora applies.
+"""
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+
+INDEX, TXT_DIR, REPORT, OUT = sys.argv[1:5]
+
+COURT = "المحكمة الاتحادية العليا"
+LISTING = ("https://www.moj.gov.ae/ar/about-moj/union-supreme-court/"
+           "e-services/latest-court-interpretations.aspx")
+# "الطعن رقم 181 لسنة 2026 جزائي"
+CASE_NO = re.compile(r"رقم\s*([\d٠-٩/\-]+)\s*(?:لسنة|لسنه)\s*(\d{4})")
+DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+
+quality = {}
+for line in open(REPORT, encoding="utf-8"):
+    r = json.loads(line)
+    quality[r["id"]] = r
+
+
+def parse_date(raw):
+    if not raw:
+        return None
+    try:
+        return datetime.datetime.strptime(raw.split(" ")[0], "%m/%d/%Y").date().isoformat()
+    except ValueError:
+        return None
+
+
+written = missing = 0
+with open(OUT, "w", encoding="utf-8") as out:
+    for item in json.load(open(INDEX, encoding="utf-8"))["d"]["items"]:
+        doc_id = str(item["id"])
+        path = os.path.join(TXT_DIR, doc_id + ".txt")
+        if not os.path.exists(path) or os.path.getsize(path) < 200:
+            missing += 1
+            continue
+        text = open(path, encoding="utf-8").read()
+        asset = (item.get("assets") or [{}])[0]
+        title = (item.get("title") or "").strip()
+        m = CASE_NO.search(title)
+        case_number = ("%s/%s" % (m.group(1).translate(DIGITS), m.group(2))) if m else None
+        q = quality.get(doc_id)
+        # no quality row means the document was never a PDF - see fetch_docx.py
+        source_kind = "docx" if q is None else ("pdf_text" if q["ok"] else "ocr")
+        q = q or {}
+        out.write(json.dumps({
+            "doc_id": "moj_fsc_" + doc_id,
+            "source": "moj_fsc",
+            "jurisdiction": "AE-FED",
+            "court_name": COURT,
+            "court_level": "supreme",
+            "case_number": case_number,
+            "case_title": title,
+            "decision_date": parse_date(item.get("date")),
+            "language": "ar",
+            "decision_type": item.get("category"),
+            "full_text": text,
+            "text_source": source_kind,
+            "source_url": LISTING,
+            "pdf_url": "https://www.moj.gov.ae/" + asset.get("downloadLink", ""),
+            "content_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "metadata_json": {
+                "moj_id": item["id"],
+                "asset_id": asset.get("id"),
+                "asset_size": asset.get("size"),
+                "download_count": asset.get("downloadCount"),
+                "chamber": item.get("category"),
+                "year": item.get("year"),
+                "group_title": item.get("groupTitle"),
+                "pages": q.get("pages"),
+                "dup_per_1000": q.get("dup_per_1000"),
+                "extraction_ok": bool(q.get("ok")),
+            },
+        }, ensure_ascii=False) + "\n")
+        written += 1
+
+print("wrote %d rows, %d without text" % (written, missing))

--- a/scripts/uae/moj/download_pdfs.sh
+++ b/scripts/uae/moj/download_pdfs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Download every judgment PDF listed in the index, resumably.
+#
+# Files already on disk that start with %PDF are left alone, so re-running is
+# cheap and an interrupted run continues where it stopped.  A missing or blocked
+# document answers with HTML rather than a 404, hence the magic-byte check.
+set -uo pipefail
+
+IDX="${1:-index.json}"
+DIR="${2:-pdf}"
+CONC="${CONC:-8}"
+UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36'
+PAGE='https://www.moj.gov.ae/ar/about-moj/union-supreme-court/e-services/latest-court-interpretations.aspx'
+
+mkdir -p "$DIR"
+python3 - "$IDX" <<'PY' > .dl_list
+import json, sys
+for i in json.load(open(sys.argv[1]))["d"]["items"]:
+    a = (i.get("assets") or [None])[0]
+    if a and a.get("downloadLink"):
+        print("%s\t%s" % (i["id"], a["downloadLink"]))
+PY
+
+fetch_one() {
+    local id="$1" link="$2" dst="$DIR/$1.pdf"
+    [ -s "$dst" ] && [ "$(head -c4 "$dst")" = "%PDF" ] && return 0
+    for attempt in 1 2 3; do
+        curl -sS --max-time 120 "https://www.moj.gov.ae/$link" -o "$dst.tmp" \
+            -H "User-Agent: $UA" -H "Referer: $PAGE" && \
+        [ -s "$dst.tmp" ] && [ "$(head -c4 "$dst.tmp")" = "%PDF" ] && {
+            mv "$dst.tmp" "$dst"; return 0; }
+        sleep $((attempt * 3))
+    done
+    rm -f "$dst.tmp"
+    echo "FAIL $id $link" >&2
+    return 1
+}
+export -f fetch_one
+export DIR UA PAGE
+
+xargs -P "$CONC" -n 2 bash -c 'fetch_one "$0" "$1"' < <(tr '\t' '\n' < .dl_list)
+
+total=$(wc -l < .dl_list)
+have=$(find "$DIR" -name '*.pdf' -size +1k | wc -l)
+echo "downloaded $have / $total"
+[ "$have" -eq "$total" ]

--- a/scripts/uae/moj/extract_all.py
+++ b/scripts/uae/moj/extract_all.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Extract text from every downloaded judgment and flag the ones needing OCR.
+
+Two things can be wrong with a document, and they need different answers:
+
+* the *encoding* of the text layer is broken (reversed lam-alef ligatures,
+  presentation forms, stray kashida codepoints) - moj_text repairs that.
+* the text layer itself is somebody else's bad OCR, with letters dropped and
+  kashidas turned into doubled letters ("قاتاال" for "قاتل").  Nothing can
+  repair that from the inside, so those documents are re-OCRed from the image.
+
+The discriminator is the rate of doubled Arabic letters, which separates the two
+populations cleanly: good documents sit at 5-11 per 1000 Arabic characters, bad
+ones at 20-170.  Genuine gemination is written with shadda, not by repeating the
+letter, so a high rate really does mean a broken source.
+"""
+import glob
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from moj_text import extract  # noqa: E402
+
+DUP = re.compile(r"([ء-ي])\1")
+AR = re.compile(r"[ء-ي]")
+JUNK_THRESHOLD = 15.0  # doubled letters per 1000 Arabic chars
+MIN_CHARS = 200
+
+pdf_dir, txt_dir, report = sys.argv[1], sys.argv[2], sys.argv[3]
+os.makedirs(txt_dir, exist_ok=True)
+
+rows = []
+for path in sorted(glob.glob(os.path.join(pdf_dir, "*.pdf"))):
+    doc_id = os.path.basename(path)[:-4]
+    try:
+        text, pages = extract(path)
+    except Exception as exc:  # noqa: BLE001 - one bad file must not stop the run
+        rows.append({"id": doc_id, "ok": False, "reason": "extract_error: %s" % exc})
+        continue
+    ar = len(AR.findall(text))
+    dup = len(DUP.findall(text))
+    ratio = dup / ar * 1000 if ar else 999.0
+    ok = ar >= MIN_CHARS and ratio <= JUNK_THRESHOLD
+    if ok:
+        with open(os.path.join(txt_dir, doc_id + ".txt"), "w", encoding="utf-8") as fh:
+            fh.write(text)
+    rows.append({
+        "id": doc_id, "ok": ok, "pages": pages, "chars": len(text),
+        "arabic": ar, "dup_per_1000": round(ratio, 1),
+        "reason": None if ok else ("too_short" if ar < MIN_CHARS else "junk_text_layer"),
+    })
+
+with open(report, "w", encoding="utf-8") as fh:
+    for r in rows:
+        fh.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+bad = [r for r in rows if not r["ok"]]
+print("extracted %d, needs OCR %d (%.1f%%)" % (len(rows), len(bad),
+                                               len(bad) / max(len(rows), 1) * 100))
+for reason in sorted({r["reason"] for r in bad}):
+    print("  %s: %d" % (reason, sum(1 for r in bad if r["reason"] == reason)))

--- a/scripts/uae/moj/fetch_docx.py
+++ b/scripts/uae/moj/fetch_docx.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Handle the handful of judgments published as .docx rather than PDF.
+
+Three of 4 469 records point at a Word file.  The index calls them
+"application/pdf" all the same, so they are found by the link extension, not by
+the declared mime type.  Text comes straight out of word/document.xml - no
+converter needed, and no broken text layer to repair either.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import unicodedata
+import zipfile
+
+INDEX, TXT_DIR = sys.argv[1], sys.argv[2]
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36")
+PAGE = ("https://www.moj.gov.ae/ar/about-moj/union-supreme-court/"
+        "e-services/latest-court-interpretations.aspx")
+TAG = re.compile(r"<[^>]+>")
+
+os.makedirs(TXT_DIR, exist_ok=True)
+done = 0
+for item in json.load(open(INDEX, encoding="utf-8"))["d"]["items"]:
+    asset = (item.get("assets") or [{}])[0]
+    link = asset.get("downloadLink", "")
+    if ".docx" not in link.lower():
+        continue
+    doc_id = str(item["id"])
+    tmp = os.path.join(TXT_DIR, doc_id + ".docx")
+    subprocess.run(["curl", "-sS", "--max-time", "120",
+                    "https://www.moj.gov.ae/" + link, "-o", tmp,
+                    "-H", "User-Agent: " + UA, "-H", "Referer: " + PAGE], check=True)
+    try:
+        with zipfile.ZipFile(tmp) as z:
+            xml = z.read("word/document.xml").decode("utf-8", "replace")
+    except (zipfile.BadZipFile, KeyError) as exc:
+        print("SKIP %s: %s" % (doc_id, exc))
+        os.unlink(tmp)
+        continue
+    xml = re.sub(r"</w:p>", "\n", xml)
+    text = unicodedata.normalize("NFKC", TAG.sub("", xml))
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n[ \t]*\n+", "\n\n", text).strip()
+    with open(os.path.join(TXT_DIR, doc_id + ".txt"), "w", encoding="utf-8") as fh:
+        fh.write(text)
+    os.unlink(tmp)
+    done += 1
+    print("%s: %d chars" % (doc_id, len(text)))
+print("docx handled: %d" % done)

--- a/scripts/uae/moj/fetch_index.sh
+++ b/scripts/uae/moj/fetch_index.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Pull the complete Federal Supreme Court judgment index from moj.gov.ae.
+#
+# The listing page is an ASMX-backed widget; pageSize -1 returns every record in
+# one response (~7 MB, ~60 s), so there is no pagination to walk.  The site is
+# not geo-blocked, but it does reject requests without a browser header set.
+set -euo pipefail
+
+OUT="${1:-index.json}"
+UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36'
+PAGE='https://www.moj.gov.ae/ar/about-moj/union-supreme-court/e-services/latest-court-interpretations.aspx'
+
+curl -sS --max-time 300 \
+  'https://www.moj.gov.ae/services/AjaxHandler.asmx/LoadCategorizeAssetsList' \
+  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "User-Agent: $UA" \
+  -H "Referer: $PAGE" \
+  -H 'X-Requested-With: XMLHttpRequest' \
+  --data-binary '{"pageIndex":1,"pageSize":-1,"languageId":2,"languageCode":"ar-AE","isArchived":false,"thumbnailSizeFactor":"12c1x1680wTransparent","excludeItems":[],"keyword":"","openDataTypeID":450,"categoryId":null,"year":null,"apiLink":null}' \
+  -o "$OUT.tmp"
+
+python3 - "$OUT.tmp" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))["d"]
+n = len(d["items"])
+assert n == d["records"] and n > 4000, "short index: %d items vs %d records" % (n, d["records"])
+print("index ok: %d records, modified %s" % (n, d["dateModified"]))
+PY
+
+mv "$OUT.tmp" "$OUT"

--- a/scripts/uae/moj/moj_text.py
+++ b/scripts/uae/moj/moj_text.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Extract Arabic text from a Federal Supreme Court judgment PDF.
+
+The portal serves two generations of PDF and each is broken in its own way:
+
+* newer files store logical-order Arabic but emit every lam-alef ligature
+  reversed, as alef+lam.  Orthography cannot tell that apart from the definite
+  article, but geometry can: the decomposed alef carries **zero width** while a
+  real article's alef does not.  That is the only reliable discriminator, so the
+  swap is driven off the glyph boxes, not off a regex.
+* older files store Unicode presentation forms plus kashidas that the font maps
+  to stray non-Arabic codepoints.  NFKC folds the forms back and the strays are
+  decorative, so they are dropped.
+"""
+import re
+import sys
+import unicodedata
+
+import pymupdf
+
+ALEFS = "اأإآ"  # bare, hamza above, hamza below, madda
+LAM = "ل"
+BIDI = dict.fromkeys(map(ord, "‎‏‪‫‬‭‮"
+                              "⁦⁧⁨⁩­ـ"), None)
+ARABIC = re.compile(r"[؀-ۿﭐ-﻿]")
+
+
+def _page_text(page):
+    """Page text with reversed lam-alef ligatures put back in order."""
+    out = []
+    for block in page.get_text("rawdict")["blocks"]:
+        for line in block.get("lines", []):
+            for span in line["spans"]:
+                chars = span["chars"]
+                buf = []
+                i = 0
+                while i < len(chars):
+                    c = chars[i]
+                    nxt = chars[i + 1] if i + 1 < len(chars) else None
+                    box = c["bbox"]
+                    zero_width = (box[2] - box[0]) < 0.01
+                    if (c["c"] in ALEFS and zero_width
+                            and nxt is not None and nxt["c"] == LAM):
+                        buf.append(LAM)
+                        buf.append(c["c"])
+                        i += 2
+                        continue
+                    buf.append(c["c"])
+                    i += 1
+                out.append("".join(buf))
+            out.append("\n")
+        out.append("\n")
+    return "".join(out)
+
+
+def extract(path):
+    doc = pymupdf.open(path)
+    text = "".join(_page_text(p) for p in doc)
+    text = unicodedata.normalize("NFKC", text).translate(BIDI)
+    # kashida and other decoration the older fonts map to stray codepoints
+    text = "".join(c for c in text
+                   if c.isascii() or ARABIC.match(c) or c.isspace()
+                   or unicodedata.category(c) in ("Po", "Ps", "Pe", "Pd", "Sm"))
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n[ \t]*\n+", "\n\n", text)
+    return text.strip(), doc.page_count
+
+
+if __name__ == "__main__":
+    t, n = extract(sys.argv[1])
+    sys.stdout.write(t)

--- a/scripts/uae/moj/ocr_one.py
+++ b/scripts/uae/moj/ocr_one.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Re-OCR one judgment whose embedded text layer was judged unusable.
+
+Same recipe as the legislation corpus: rasterise with PyMuPDF at 200 dpi and run
+tesseract's Arabic model one page at a time.  OMP_THREAD_LIMIT=1 is essential -
+tesseract is OpenMP-threaded by default and several workers each spawning a full
+thread pool collapses throughput on a shared box.
+"""
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unicodedata
+
+import pymupdf
+
+os.environ.setdefault("TESSDATA_PREFIX", os.path.expanduser("~/uae/tessdata"))
+os.environ["OMP_THREAD_LIMIT"] = "1"
+BIDI = dict.fromkeys(map(ord, "‎‏‪‫‬‭‮⁦⁧⁨⁩­ـ"), None)
+
+src, dst_dir = sys.argv[1], sys.argv[2]
+doc_id = os.path.basename(src)[:-4]
+dst = os.path.join(dst_dir, doc_id + ".txt")
+if os.path.exists(dst) and os.path.getsize(dst) > 200:
+    sys.exit(0)
+
+try:
+    doc = pymupdf.open(src)
+except Exception:  # noqa: BLE001 - a corrupt file must not stall the batch
+    sys.exit(0)
+
+parts = []
+for page in doc:
+    tmp = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+            tmp = fh.name
+        page.get_pixmap(dpi=200).save(tmp)
+        out = subprocess.run(
+            ["tesseract", tmp, "stdout", "-l", "ara", "--psm", "6", "--oem", "1"],
+            capture_output=True, timeout=300)
+        parts.append(out.stdout.decode("utf-8", "replace"))
+    except Exception:  # noqa: BLE001
+        parts.append("")
+    finally:
+        if tmp:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+text = unicodedata.normalize("NFKC", "\n".join(parts)).translate(BIDI)
+text = re.sub(r"[ \t]+", " ", text)
+text = re.sub(r"\n[ \t]*\n+", "\n\n", text).strip()
+with open(dst, "w", encoding="utf-8") as fh:
+    fh.write(text)

--- a/scripts/uae/moj/run_ocr.sh
+++ b/scripts/uae/moj/run_ocr.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OCR every judgment the extractor flagged, into the same text directory.
+#
+# Five workers, niced, on an eight-core shared box: enough to finish in an hour
+# without the app noticing.  Each worker is single-threaded by ocr_one.py.
+set -uo pipefail
+
+REPORT="${1:-report.jsonl}"
+PDF_DIR="${2:-pdf}"
+TXT_DIR="${3:-txt}"
+WORKERS="${WORKERS:-5}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$TXT_DIR"
+python3 - "$REPORT" <<'PY' > .ocr_list
+import json, sys
+for line in open(sys.argv[1]):
+    r = json.loads(line)
+    if not r["ok"]:
+        print(r["id"])
+PY
+
+echo "to OCR: $(wc -l < .ocr_list)"
+xargs -P "$WORKERS" -I{} nice -n 19 ionice -c3 \
+    python3 "$HERE/ocr_one.py" "$PDF_DIR/{}.pdf" "$TXT_DIR" < .ocr_list
+echo "text files now: $(find "$TXT_DIR" -name '*.txt' -size +1k | wc -l)"

--- a/scripts/uae/sql/06_load_moj_fsc.sql
+++ b/scripts/uae/sql/06_load_moj_fsc.sql
@@ -1,0 +1,40 @@
+\set ON_ERROR_STOP on
+DROP TABLE IF EXISTS ae_stage_moj;
+CREATE TABLE ae_stage_moj(j jsonb);
+\copy ae_stage_moj(j) FROM '/tmp/ae_moj_fsc.jsonl' WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+SELECT count(*) AS staged, count(DISTINCT j->>'doc_id') AS distinct_ids FROM ae_stage_moj;
+
+INSERT INTO ae_court_decisions (doc_id, source, jurisdiction, court_name, court_level,
+                                case_number, case_title, decision_date, language,
+                                decision_type, full_text, text_source, source_url, pdf_url,
+                                content_sha256, metadata_json)
+SELECT DISTINCT ON (j->>'doc_id')
+    j->>'doc_id', j->>'source', j->>'jurisdiction', j->>'court_name', j->>'court_level',
+    j->>'case_number', j->>'case_title', NULLIF(j->>'decision_date','')::date,
+    j->>'language', j->>'decision_type', j->>'full_text', j->>'text_source',
+    j->>'source_url', j->>'pdf_url', j->>'content_sha256', j->'metadata_json'
+FROM ae_stage_moj
+ORDER BY j->>'doc_id', length(j->>'full_text') DESC NULLS LAST
+ON CONFLICT (doc_id) DO UPDATE SET
+    full_text = EXCLUDED.full_text, case_title = EXCLUDED.case_title,
+    case_number = EXCLUDED.case_number, decision_date = EXCLUDED.decision_date,
+    decision_type = EXCLUDED.decision_type, text_source = EXCLUDED.text_source,
+    content_sha256 = EXCLUDED.content_sha256, metadata_json = EXCLUDED.metadata_json,
+    updated_at = now();
+DROP TABLE ae_stage_moj;
+
+\echo '=== Federal Supreme Court loaded ==='
+SELECT count(*) AS judgments,
+       count(*) FILTER (WHERE text_source = 'ocr') AS ocred,
+       min(decision_date) AS first, max(decision_date) AS last,
+       pg_size_pretty(sum(length(full_text))::bigint) AS text_volume
+FROM ae_court_decisions WHERE source = 'moj_fsc';
+\echo '=== by year ==='
+SELECT extract(year FROM decision_date)::int AS yr, count(*)
+FROM ae_court_decisions WHERE source = 'moj_fsc' GROUP BY 1 ORDER BY 1;
+\echo '=== by chamber ==='
+SELECT decision_type, count(*) FROM ae_court_decisions
+WHERE source = 'moj_fsc' GROUP BY 1 ORDER BY 2 DESC;
+\echo '=== whole AE corpus ==='
+SELECT source, count(*), min(decision_date) AS first, max(decision_date) AS last
+FROM ae_court_decisions GROUP BY 1 ORDER BY 2 DESC;

--- a/scripts/uae/sql/07_create_amendments.sql
+++ b/scripts/uae/sql/07_create_amendments.sql
@@ -1,0 +1,74 @@
+\set ON_ERROR_STOP on
+
+-- Publication and status facts the downloadable PDFs never carried.
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS issue_date date;
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS effective_date date;
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS gazette_date date;
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS gazette_number text;
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS status text;
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS status_ar text;
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS last_update date;
+ALTER TABLE ae_legislation ADD COLUMN IF NOT EXISTS amendments_count int;
+
+CREATE INDEX IF NOT EXISTS idx_ae_leg_status ON ae_legislation (status);
+CREATE INDEX IF NOT EXISTS idx_ae_leg_issue_date ON ae_legislation (issue_date DESC);
+
+-- One row per amending act, in the acts it amends.
+CREATE TABLE IF NOT EXISTS ae_legislation_amendments (
+    amendment_id     text PRIMARY KEY,
+    law_id           int NOT NULL,
+    modification_id  int,
+    amend_date       date,
+    amend_year       int,
+    amend_date_raw   text,
+    amending_title   text,
+    amending_law_id  int,          -- resolved against ae_legislation where possible
+    amending_pdf_url text,
+    articles_changed int,
+    imported_at      timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_ae_amend_law ON ae_legislation_amendments (law_id, amend_date);
+CREATE INDEX IF NOT EXISTS idx_ae_amend_date ON ae_legislation_amendments (amend_date DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_amend_source_law ON ae_legislation_amendments (amending_law_id);
+
+-- One row per article an amendment touched: the new text beside the old one.
+CREATE TABLE IF NOT EXISTS ae_legislation_article_changes (
+    change_id         text PRIMARY KEY,
+    amendment_id      text NOT NULL REFERENCES ae_legislation_amendments(amendment_id)
+                          ON DELETE CASCADE,
+    law_id            int NOT NULL,
+    seq               int,
+    article_label     text,
+    article_no        text,
+    new_text          text,
+    previous_text     text,
+    new_sha256        text,
+    previous_sha256   text,
+    previous_versions int,
+    text_changed      boolean,
+    imported_at       timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_ae_change_law_article
+    ON ae_legislation_article_changes (law_id, article_no);
+CREATE INDEX IF NOT EXISTS idx_ae_change_amendment
+    ON ae_legislation_article_changes (amendment_id);
+CREATE INDEX IF NOT EXISTS idx_ae_change_fts_ar
+    ON ae_legislation_article_changes
+    USING gin (to_tsvector('arabic', coalesce(new_text, '')))
+    WHERE new_text IS NOT NULL;
+
+-- What each article looks like now and what it looked like before, in one place.
+CREATE OR REPLACE VIEW ae_legislation_article_history AS
+SELECT c.law_id,
+       l.title           AS law_title,
+       c.article_no,
+       c.article_label,
+       a.amend_date,
+       a.amending_title,
+       c.previous_text   AS text_before,
+       c.new_text        AS text_after,
+       c.text_changed
+FROM ae_legislation_article_changes c
+JOIN ae_legislation_amendments a USING (amendment_id)
+LEFT JOIN ae_legislation l ON l.law_id = c.law_id
+ORDER BY c.law_id, c.article_no, a.amend_date;

--- a/scripts/uae/sql/08_load_amendments.sql
+++ b/scripts/uae/sql/08_load_amendments.sql
@@ -89,6 +89,14 @@ SELECT (amend_year / 10) * 10 AS decade, count(*)
 FROM ae_legislation_amendments WHERE amend_year IS NOT NULL GROUP BY 1 ORDER BY 1;
 
 \echo '=== most-amended acts ==='
-SELECT a.law_id, count(*) AS amendments, left(l.title, 70) AS title
+-- Identify acts by number and year, never by a prefix of the text: both left()
+-- and substring() raise a spurious "invalid byte sequence" on these columns.
+SELECT a.law_id, l.law_type, l.law_number, l.law_year, count(*) AS amendments
 FROM ae_legislation_amendments a LEFT JOIN ae_legislation l USING (law_id)
-GROUP BY a.law_id, l.title ORDER BY 2 DESC LIMIT 10;
+GROUP BY 1, 2, 3, 4 ORDER BY 5 DESC LIMIT 10;
+
+\echo '=== most recent article changes ==='
+SELECT law_id, article_label, amend_date,
+       length(text_before) AS len_before, length(text_after) AS len_after
+FROM ae_legislation_article_history
+WHERE text_changed ORDER BY amend_date DESC LIMIT 8;

--- a/scripts/uae/sql/08_load_amendments.sql
+++ b/scripts/uae/sql/08_load_amendments.sql
@@ -1,0 +1,94 @@
+\set ON_ERROR_STOP on
+
+DROP TABLE IF EXISTS ae_stage_laws, ae_stage_amend, ae_stage_change;
+CREATE TABLE ae_stage_laws(j jsonb);
+CREATE TABLE ae_stage_amend(j jsonb);
+CREATE TABLE ae_stage_change(j jsonb);
+\copy ae_stage_laws(j)   FROM '/tmp/leg_laws.jsonl'       WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+\copy ae_stage_amend(j)  FROM '/tmp/leg_amendments.jsonl' WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+\copy ae_stage_change(j) FROM '/tmp/leg_changes.jsonl'    WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+SELECT (SELECT count(*) FROM ae_stage_laws)   AS laws,
+       (SELECT count(*) FROM ae_stage_amend)  AS amendments,
+       (SELECT count(*) FROM ae_stage_change) AS changes;
+
+UPDATE ae_legislation l SET
+    issue_date     = NULLIF(s.j->>'issue_date','')::date,
+    effective_date = NULLIF(s.j->>'effective_date','')::date,
+    gazette_date   = NULLIF(s.j->>'gazette_date','')::date,
+    gazette_number = s.j->>'gazette_number',
+    status         = s.j->>'status',
+    status_ar      = s.j->>'status_ar',
+    last_update    = NULLIF(s.j->>'last_update','')::date,
+    amendments_count = NULLIF(s.j->>'amendments_declared','')::int,
+    updated_at     = now()
+FROM ae_stage_laws s
+WHERE l.law_id = (s.j->>'law_id')::int;
+
+INSERT INTO ae_legislation_amendments (amendment_id, law_id, modification_id, amend_date,
+        amend_year, amend_date_raw, amending_title, amending_pdf_url, articles_changed)
+SELECT DISTINCT ON (j->>'amendment_id')
+    j->>'amendment_id', (j->>'law_id')::int, NULLIF(j->>'modification_id','')::int,
+    NULLIF(j->>'amend_date','')::date, NULLIF(j->>'amend_year','')::int,
+    j->>'amend_date_raw', j->>'amending_title', j->>'amending_pdf_url',
+    NULLIF(j->>'articles_changed','')::int
+FROM ae_stage_amend
+ORDER BY j->>'amendment_id'
+ON CONFLICT (amendment_id) DO UPDATE SET
+    amend_date = EXCLUDED.amend_date, amending_title = EXCLUDED.amending_title,
+    articles_changed = EXCLUDED.articles_changed;
+
+INSERT INTO ae_legislation_article_changes (change_id, amendment_id, law_id, seq,
+        article_label, article_no, new_text, previous_text, new_sha256,
+        previous_sha256, previous_versions, text_changed)
+SELECT DISTINCT ON (j->>'change_id')
+    j->>'change_id', j->>'amendment_id', (j->>'law_id')::int, NULLIF(j->>'seq','')::int,
+    j->>'article_label', j->>'article_no', j->>'new_text', j->>'previous_text',
+    j->>'new_sha256', j->>'previous_sha256', NULLIF(j->>'previous_versions','')::int,
+    (j->>'text_changed')::boolean
+FROM ae_stage_change
+ORDER BY j->>'change_id'
+ON CONFLICT (change_id) DO UPDATE SET
+    new_text = EXCLUDED.new_text, previous_text = EXCLUDED.previous_text,
+    new_sha256 = EXCLUDED.new_sha256, previous_sha256 = EXCLUDED.previous_sha256,
+    text_changed = EXCLUDED.text_changed;
+
+-- Resolve each amending act to the act in our corpus, by its number and year.
+UPDATE ae_legislation_amendments a SET amending_law_id = l.law_id
+FROM ae_legislation l
+WHERE a.amending_law_id IS NULL
+  AND l.law_number IS NOT NULL AND l.law_year IS NOT NULL
+  AND a.amending_title ~ ('رقم[^0-9]{0,4}' || l.law_number || '[^0-9]')
+  AND a.amending_title LIKE '%لسنة ' || l.law_year || '%';
+
+DROP TABLE ae_stage_laws, ae_stage_amend, ae_stage_change;
+
+\echo '=== acts with publication metadata ==='
+SELECT count(*) AS acts,
+       count(issue_date) AS with_issue_date,
+       count(gazette_number) AS with_gazette,
+       count(*) FILTER (WHERE status = 'in_force') AS in_force,
+       count(*) FILTER (WHERE status = 'repealed') AS repealed
+FROM ae_legislation;
+
+\echo '=== amendments ==='
+SELECT count(*) AS amendments,
+       count(DISTINCT law_id) AS laws_amended,
+       count(amending_law_id) AS linked_to_an_act_we_hold,
+       min(amend_date) AS first, max(amend_date) AS last
+FROM ae_legislation_amendments;
+
+\echo '=== article-level changes ==='
+SELECT count(*) AS changes,
+       count(*) FILTER (WHERE previous_text IS NOT NULL) AS with_previous_text,
+       count(*) FILTER (WHERE text_changed) AS text_actually_differs,
+       count(DISTINCT law_id) AS laws
+FROM ae_legislation_article_changes;
+
+\echo '=== amendments per decade ==='
+SELECT (amend_year / 10) * 10 AS decade, count(*)
+FROM ae_legislation_amendments WHERE amend_year IS NOT NULL GROUP BY 1 ORDER BY 1;
+
+\echo '=== most-amended acts ==='
+SELECT a.law_id, count(*) AS amendments, left(l.title, 70) AS title
+FROM ae_legislation_amendments a LEFT JOIN ae_legislation l USING (law_id)
+GROUP BY a.law_id, l.title ORDER BY 2 DESC LIMIT 10;

--- a/scripts/uae/sql/09_load_articles.sql
+++ b/scripts/uae/sql/09_load_articles.sql
@@ -1,0 +1,71 @@
+\set ON_ERROR_STOP on
+
+CREATE TABLE IF NOT EXISTS ae_legislation_articles (
+    article_id     text PRIMARY KEY,
+    law_id         int NOT NULL,
+    material_id    int,            -- the portal's own id; what amendments key on
+    seq            int,
+    chapter        text,
+    article_label  text,
+    article_no     text,
+    text           text,
+    has_previous   boolean,        -- the act's own marker that this article was amended
+    content_sha256 text,
+    imported_at    timestamptz DEFAULT now(),
+    updated_at     timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_ae_art_law ON ae_legislation_articles (law_id, seq);
+CREATE INDEX IF NOT EXISTS idx_ae_art_no ON ae_legislation_articles (law_id, article_no);
+CREATE INDEX IF NOT EXISTS idx_ae_art_material ON ae_legislation_articles (material_id);
+CREATE INDEX IF NOT EXISTS idx_ae_art_amended ON ae_legislation_articles (has_previous)
+    WHERE has_previous;
+CREATE INDEX IF NOT EXISTS idx_ae_art_fts_ar ON ae_legislation_articles
+    USING gin (to_tsvector('arabic', coalesce(article_label, '') || ' ' || coalesce(text, '')))
+    WHERE text IS NOT NULL;
+
+DROP TABLE IF EXISTS ae_stage_art;
+CREATE TABLE ae_stage_art(j jsonb);
+\copy ae_stage_art(j) FROM '/tmp/leg_articles.jsonl' WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+SELECT count(*) AS staged FROM ae_stage_art;
+
+INSERT INTO ae_legislation_articles (article_id, law_id, material_id, seq, chapter,
+        article_label, article_no, text, has_previous, content_sha256)
+SELECT DISTINCT ON (j->>'article_id')
+    j->>'article_id', (j->>'law_id')::int, NULLIF(j->>'material_id','')::int,
+    NULLIF(j->>'seq','')::int, j->>'chapter', j->>'article_label', j->>'article_no',
+    j->>'text', (j->>'has_previous')::boolean, j->>'content_sha256'
+FROM ae_stage_art
+ORDER BY j->>'article_id', length(j->>'text') DESC NULLS LAST
+ON CONFLICT (article_id) DO UPDATE SET
+    text = EXCLUDED.text, article_label = EXCLUDED.article_label,
+    chapter = EXCLUDED.chapter, has_previous = EXCLUDED.has_previous,
+    content_sha256 = EXCLUDED.content_sha256, updated_at = now();
+DROP TABLE ae_stage_art;
+
+\echo '=== articles ==='
+SELECT count(*) AS articles, count(DISTINCT law_id) AS acts,
+       count(*) FILTER (WHERE has_previous) AS marked_amended,
+       count(chapter) AS with_chapter,
+       pg_size_pretty(sum(length(text))::bigint) AS text_volume
+FROM ae_legislation_articles;
+
+\echo '=== coverage against the act-level corpus ==='
+SELECT count(*) AS acts_total,
+       count(*) FILTER (WHERE a.law_id IS NOT NULL) AS acts_with_articles
+FROM ae_legislation l
+LEFT JOIN (SELECT DISTINCT law_id FROM ae_legislation_articles) a USING (law_id);
+
+\echo '=== articles per act ==='
+SELECT CASE WHEN n <= 10 THEN '1-10' WHEN n <= 50 THEN '11-50'
+            WHEN n <= 200 THEN '51-200' ELSE '200+' END AS bucket, count(*) AS acts
+FROM (SELECT law_id, count(*) AS n FROM ae_legislation_articles GROUP BY 1) t
+GROUP BY 1 ORDER BY min(n);
+
+\echo '=== does the per-article amendment marker agree with the amendment tables? ==='
+SELECT count(*) FILTER (WHERE a.has_previous) AS marked_by_the_act,
+       count(*) FILTER (WHERE c.article_id IS NOT NULL) AS matched_a_recorded_change
+FROM ae_legislation_articles a
+LEFT JOIN (SELECT DISTINCT law_id, article_no,
+                  'x' AS article_id FROM ae_legislation_article_changes) c
+       ON c.law_id = a.law_id AND c.article_no = a.article_no
+WHERE a.has_previous;

--- a/scripts/uae/sql/10_load_citations.sql
+++ b/scripts/uae/sql/10_load_citations.sql
@@ -1,0 +1,89 @@
+\set ON_ERROR_STOP on
+
+CREATE TABLE IF NOT EXISTS ae_case_legislation_citations (
+    citation_id text PRIMARY KEY,
+    doc_id      text NOT NULL,
+    law_type    text,          -- normalised from the wording used in the judgment
+    kind_ar     text,          -- the wording itself
+    law_number  text,
+    law_year    int,
+    law_id      int,           -- resolved against ae_legislation, null when unknown
+    resolution  text,          -- how it was resolved, so weak links stay visible
+    articles    text[],        -- article numbers named beside the citation
+    mentions    int,
+    raw         text,
+    imported_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_ae_cit_doc ON ae_case_legislation_citations (doc_id);
+CREATE INDEX IF NOT EXISTS idx_ae_cit_law ON ae_case_legislation_citations (law_id);
+CREATE INDEX IF NOT EXISTS idx_ae_cit_numyear ON ae_case_legislation_citations (law_number, law_year);
+
+DROP TABLE IF EXISTS ae_stage_cit;
+CREATE TABLE ae_stage_cit(j jsonb);
+\copy ae_stage_cit(j) FROM '/tmp/citations.jsonl' WITH (FORMAT csv, QUOTE E'\x01', DELIMITER E'\x02')
+SELECT count(*) AS staged FROM ae_stage_cit;
+
+INSERT INTO ae_case_legislation_citations (citation_id, doc_id, law_type, kind_ar,
+        law_number, law_year, articles, mentions, raw)
+SELECT DISTINCT ON (j->>'citation_id')
+    j->>'citation_id', j->>'doc_id', j->>'law_type', j->>'kind_ar',
+    j->>'law_number', (j->>'law_year')::int,
+    ARRAY(SELECT jsonb_array_elements_text(j->'articles')),
+    NULLIF(j->>'mentions','')::int, j->>'raw'
+FROM ae_stage_cit
+ORDER BY j->>'citation_id'
+ON CONFLICT (citation_id) DO UPDATE SET
+    articles = EXCLUDED.articles, mentions = EXCLUDED.mentions;
+DROP TABLE ae_stage_cit;
+
+-- Resolution runs strongest-first and records which rule fired, so a weak link
+-- can be filtered out later rather than being indistinguishable from a firm one.
+UPDATE ae_case_legislation_citations c SET law_id = l.law_id, resolution = 'type+number+year'
+FROM ae_legislation l
+WHERE c.law_id IS NULL AND l.law_number = c.law_number AND l.law_year = c.law_year
+  AND l.law_type = c.law_type;
+
+UPDATE ae_case_legislation_citations c SET law_id = u.law_id, resolution = 'number+year'
+FROM (SELECT law_number, law_year, min(law_id) AS law_id
+      FROM ae_legislation WHERE law_number IS NOT NULL AND law_year IS NOT NULL
+      GROUP BY 1, 2 HAVING count(*) = 1) u
+WHERE c.law_id IS NULL AND u.law_number = c.law_number AND u.law_year = c.law_year;
+
+-- Judgment -> article, wherever the cited article exists in the article corpus.
+CREATE OR REPLACE VIEW ae_case_article_citations AS
+SELECT c.doc_id, c.law_id, c.law_number, c.law_year, art AS article_no,
+       a.article_id, a.article_label, a.text AS article_text
+FROM ae_case_legislation_citations c
+CROSS JOIN LATERAL unnest(c.articles) AS art
+LEFT JOIN ae_legislation_articles a
+       ON a.law_id = c.law_id AND a.article_no = art
+WHERE c.law_id IS NOT NULL;
+
+\echo '=== citations ==='
+SELECT count(*) AS citations, count(DISTINCT doc_id) AS judgments,
+       count(law_id) AS resolved, count(DISTINCT law_id) AS distinct_acts,
+       count(*) FILTER (WHERE cardinality(articles) > 0) AS with_article_numbers
+FROM ae_case_legislation_citations;
+
+\echo '=== how they resolved ==='
+SELECT coalesce(resolution, 'unresolved') AS rule, count(*)
+FROM ae_case_legislation_citations GROUP BY 1 ORDER BY 2 DESC;
+
+\echo '=== citing judgments per source ==='
+SELECT d.source, count(DISTINCT d.doc_id) AS judgments_total,
+       count(DISTINCT c.doc_id) AS judgments_citing
+FROM ae_court_decisions d
+LEFT JOIN ae_case_legislation_citations c USING (doc_id)
+GROUP BY 1 ORDER BY 2 DESC;
+
+\echo '=== most-cited acts ==='
+SELECT c.law_id, c.law_number, c.law_year, l.law_type,
+       count(DISTINCT c.doc_id) AS citing_judgments
+FROM ae_case_legislation_citations c JOIN ae_legislation l USING (law_id)
+GROUP BY 1, 2, 3, 4 ORDER BY 5 DESC LIMIT 15;
+
+\echo '=== judgment -> article edges that land on a real article ==='
+SELECT count(*) AS article_edges,
+       count(article_id) AS matched_an_article_we_hold,
+       count(DISTINCT doc_id) AS judgments
+FROM ae_case_article_citations;

--- a/scripts/uae/sql/11_resolve_citations.sql
+++ b/scripts/uae/sql/11_resolve_citations.sql
@@ -1,0 +1,97 @@
+\set ON_ERROR_STOP on
+
+-- Judgments name an act more loosely than the corpus types it: "القانون رقم 42
+-- لسنة 2022" says nothing about decree versus law, and the same number and year
+-- can belong to several instruments.  These passes relax the match in defined
+-- steps and record which step fired, so a firm link and a weaker one never look
+-- alike downstream.
+--
+-- What does NOT work, and was tried: ranking the candidates by how specific the
+-- instrument type is.  It resolves everything and is confidently wrong - the
+-- Arbitration Law 6/2018 came out as the supplementary budget decree 6/2018,
+-- which is a plausible-looking edge that would quietly poison the graph.  The
+-- subject phrase a judgment gives alongside the number ("بشأن التحكيم") is the
+-- signal that actually distinguishes them, and where there is no subject phrase
+-- the citation is left unresolved rather than guessed.
+
+DROP VIEW IF EXISTS ae_legislation_type_rank;
+CREATE VIEW ae_legislation_type_rank AS
+SELECT law_id, law_number, law_year, law_type,
+       CASE WHEN law_type IN ('resolution', 'cabinet_resolution',
+                              'ministerial_resolution', 'regulation')
+            THEN 'res' ELSE 'law' END AS family
+FROM ae_legislation
+WHERE law_number IS NOT NULL AND law_year IS NOT NULL;
+
+-- Undo the ranked guesses from any earlier run of this script.
+UPDATE ae_case_legislation_citations
+SET law_id = NULL, resolution = NULL
+WHERE resolution IN ('family+number+year (ambiguous)', 'subject+number+year');
+
+-- Pass 3: same number, year and type family, and only one act qualifies.
+WITH unique_family AS (
+    SELECT law_number, law_year, family, min(law_id) AS law_id
+    FROM ae_legislation_type_rank GROUP BY 1, 2, 3 HAVING count(*) = 1)
+UPDATE ae_case_legislation_citations c
+SET law_id = u.law_id, resolution = 'family+number+year'
+FROM unique_family u
+WHERE c.law_id IS NULL AND u.law_number = c.law_number AND u.law_year = c.law_year
+  AND u.family = CASE WHEN c.law_type IN ('resolution', 'cabinet_resolution',
+                                          'ministerial_resolution', 'regulation')
+                      THEN 'res' ELSE 'law' END;
+
+-- Pass 4: several acts share the number and year, so decide on the subject the
+-- judgment named alongside it.
+--
+-- word_similarity, not similarity: the subject is a short phrase and the title
+-- is long, and plain trigram similarity drowns the signal - on decree-law
+-- 33/2021 it scored the right act 0.095 and the wrong one 0.057, while
+-- word_similarity gave 0.42 against 0.16. A win must also clear the runner-up by
+-- a margin, so that a genuinely undecidable pair is left unresolved instead of
+-- being decided by noise.
+WITH subj AS (
+    SELECT citation_id, law_number, law_year,
+           substring(regexp_replace(raw, '\s+', ' ', 'g')
+                     from '(?:بشأن|في شأن|بإصدار)\s+(.{6,60})') AS subject
+    FROM ae_case_legislation_citations
+    WHERE law_id IS NULL),
+scored AS (
+    SELECT s.citation_id, l.law_id,
+           word_similarity(s.subject, l.title) AS sim,
+           row_number() OVER (PARTITION BY s.citation_id
+                              ORDER BY word_similarity(s.subject, l.title) DESC) AS rn,
+           lead(word_similarity(s.subject, l.title)) OVER (
+               PARTITION BY s.citation_id
+               ORDER BY word_similarity(s.subject, l.title) DESC) AS runner_up
+    FROM subj s
+    JOIN ae_legislation l ON l.law_number = s.law_number AND l.law_year = s.law_year
+    WHERE s.subject IS NOT NULL AND l.title IS NOT NULL)
+UPDATE ae_case_legislation_citations c
+SET law_id = sc.law_id, resolution = 'subject+number+year'
+FROM scored sc
+WHERE c.citation_id = sc.citation_id AND c.law_id IS NULL
+  AND sc.rn = 1 AND sc.sim >= 0.25
+  AND (sc.runner_up IS NULL OR sc.sim >= sc.runner_up * 1.4);
+
+\echo '=== resolution after all passes ==='
+SELECT coalesce(resolution, 'unresolved') AS rule, count(*) AS citations,
+       round(100.0 * count(*) / sum(count(*)) OVER (), 1) AS pct
+FROM ae_case_legislation_citations GROUP BY 1 ORDER BY 2 DESC;
+
+\echo '=== coverage ==='
+SELECT count(*) AS citations, count(law_id) AS resolved,
+       count(DISTINCT doc_id) AS judgments,
+       count(DISTINCT doc_id) FILTER (WHERE law_id IS NOT NULL) AS judgments_with_a_resolved_act,
+       count(DISTINCT law_id) AS distinct_acts
+FROM ae_case_legislation_citations;
+
+\echo '=== the unresolved remainder is dominated by acts we do not hold ==='
+SELECT law_number, law_year, count(*) AS citations
+FROM ae_case_legislation_citations WHERE law_id IS NULL
+GROUP BY 1, 2 ORDER BY 3 DESC LIMIT 10;
+
+\echo '=== judgment -> article edges ==='
+SELECT count(*) AS article_edges,
+       count(article_id) AS matched_an_article_we_hold,
+       count(DISTINCT doc_id) AS judgments
+FROM ae_case_article_citations;


### PR DESCRIPTION
Two UAE sources that were on record as unreachable turn out to be open, and neither needed a proxy.

## Federal Supreme Court — 4 457 judgments, 2009-2026

Loaded into `ae_court_decisions` as `source='moj_fsc'` (38 MB of Arabic text). The whole AE corpus is now **446 278** decisions.

`moj.gov.ae` was never geo-blocked. Its ASMX listing endpoint answers a bare **500 to any wrong parameter set**, with `?WSDL` and the help page disabled, which reads exactly like a block. The working body needs `openDataTypeID` — capital `ID`, unlike every neighbouring key — and `pageSize: -1`, which returns all 4 469 records in one 7 MB response. No pagination to walk.

The PDFs come in two broken generations:

- Newer files reverse every lam-alef ligature (`الأربعاء` → `األربعاء`). Orthography cannot separate that from the definite article `ال`, but **the decomposed alef has zero glyph width** and a real article's does not, so the repair reads glyph boxes rather than applying a regex that would eat every article in the corpus. Verified byte-identical across PyMuPDF 1.27 and 1.28.
- Older files store presentation forms and stray kashida codepoints; NFKC and a script filter clear them.

A third of the documents carry the court's own bad OCR, which no decoder can repair. Doubled-letter rate separates the populations cleanly (5-11 per 1000 Arabic chars against 20-170), so those are re-OCRed; a 12-document sample all returned to the good band.

## Amendment history — 427 amendments, 1 313 article changes

The portal keeps a per-article history the downloadable PDFs never show: for each amending act, the new text of every article it touched **beside the text it replaced**. Three tables plus a view record it, along with the publication metadata (gazette reference, effective date, in-force status) that the act-level corpus lacked — 2 154 of 2 862 acts are now dated.

Cloudflare there scores the **TLS fingerprint, not the IP**: plain curl gets 403 from the laptop, from prod and from the me-central-1 Lambda alike, while a browser-shaped handshake gets 200 from those same hosts. An act with no amendments has no page at all and answers 500, so that status is an answer rather than a failure to retry.

## Verification

Both corpora are loaded and queried on prod; counts in this description are from the load output, not estimates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds UAE Federal Supreme Court judgments, UAE federal legislation amendment history, per‑article text, and links from judgments to the federal acts and articles they cite. Extracted 297,968 citations from 169,758 Arabic judgments; 201,461 resolve to 820 acts, and 220,055 judgment→article edges include 128,178 that match articles we hold.

- **New Features**
  - Federal Supreme Court judgments: fetch ASMX index (`openDataTypeID`, `pageSize:-1`), download PDFs/DOCX, repair Arabic text (glyph‑box lam‑alef fix, NFKC cleanup), OCR fallback with `tesseract` for bad text layers; build JSONL and load with `sql/06_load_moj_fsc.sql`.
  - Amendment history: harvest modifications with `curl_cffi` TLS impersonation, parse to `laws.jsonl`, `amendments.jsonl`, `changes.jsonl`, and download amending PDFs. New DB: columns on `ae_legislation`, tables `ae_legislation_amendments`, `ae_legislation_article_changes`, and view `ae_legislation_article_history`; loader resolves amending acts to `ae_legislation`.
  - Article-level text: fetch per‑article HTML via `/materials-ajax`, parse to `leg_articles.jsonl` with portal `material_id`, and load into `ae_legislation_articles` via `sql/09_load_articles.sql`. Coverage: 23,669 articles across 2,082 acts.
  - Judgment → legislation citations: extract tolerant patterns (handles glued numbers, parentheses, Arabic‑Indic digits) and capture article numbers; load into `ae_case_legislation_citations` and view `ae_case_article_citations`. Resolution passes: exact type+number+year; unique number+year; family+number+year; subject‑phrase match using `word_similarity` with a margin. Acts cited by name only are left unresolved. Many unresolved point to acts we don’t hold (e.g., repealed 11/1992).

- **Migration**
  - Ensure `tesseract` (Arabic model), `PyMuPDF`, `curl_cffi`, and Postgres `pg_trgm` are available.
  - Place JSONL outputs in `/tmp/ae_moj_fsc.jsonl`, `/tmp/leg_laws.jsonl`, `/tmp/leg_amendments.jsonl`, `/tmp/leg_changes.jsonl`, `/tmp/leg_articles.jsonl`, `/tmp/citations.jsonl`.
  - Run `sql/07_create_amendments.sql`, `sql/08_load_amendments.sql`, `sql/09_load_articles.sql`, `sql/06_load_moj_fsc.sql`, `sql/10_load_citations.sql`, and `sql/11_resolve_citations.sql`.

<sup>Written for commit bb17538709be999687749496bca7b7345d4decdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

