### PR TITLE
fix(edrsr): refresh the judge lookup after each sync

### DIFF
--- a/scripts/edrsr/sync-edrsr-incremental.sh
+++ b/scripts/edrsr/sync-edrsr-incremental.sh
@@ -264,6 +264,39 @@ log "New records imported: $NEW_RECORDS"
 LATEST=$(run_sql "SELECT max(receipt_date)::date FROM edrsr_documents WHERE EXTRACT(YEAR FROM receipt_date) = $YEAR;" 2>/dev/null | grep -oP '\d{4}-\d{2}-\d{2}' | head -1 || echo "unknown")
 log "Latest receipt_date for $YEAR: $LATEST"
 
+# ── Step 7: Refresh the distinct-judge lookup ─────────────────────────
+# The judge filter in search_court_decisions resolves a name fragment against
+# edrsr_judges_distinct rather than substring-scanning edrsr_documents (135.8M rows
+# over 26 partitions — 83-120s before, 33ms after; migration 183).
+#
+# That view is materialised, so a judge whose first decision arrives in THIS sync
+# stays invisible to the filter until it is refreshed. The failure mode is silent:
+# a search for that judge returns "nothing found" rather than an error, so nobody
+# notices until someone wonders why a real judge has no decisions.
+#
+# CONCURRENTLY keeps readers unblocked; it requires the unique index idx_ejd_judge,
+# which migration 183 creates for precisely this. Measured on prod at 13.1s over
+# 135.8M rows, so there is nothing to optimise by doing it incrementally.
+#
+# This is auxiliary to the import: a failure here warns loudly but must not fail the
+# sync, and a missing view (migration not yet applied) is not an error at all —
+# resolveJudgeNames falls back to the old substring predicate in that case.
+if [ "$NEW_RECORDS" -gt 0 ]; then
+  if [ "$(count_sql "SELECT count(*) FROM pg_matviews WHERE matviewname = 'edrsr_judges_distinct';")" -gt 0 ]; then
+    log "Refreshing edrsr_judges_distinct (judge lookup)..."
+    if run_sql "REFRESH MATERIALIZED VIEW CONCURRENTLY edrsr_judges_distinct;" >/dev/null 2>&1; then
+      JUDGES=$(count_sql "SELECT count(*) FROM edrsr_judges_distinct;")
+      log "Judge lookup refreshed: $JUDGES distinct judges"
+    else
+      log "WARNING: REFRESH of edrsr_judges_distinct failed — the judge filter will not see judges added by this sync"
+    fi
+  else
+    log "edrsr_judges_distinct absent (migration 183 not applied) — skipping judge lookup refresh"
+  fi
+else
+  log "No new records — judge lookup refresh not needed"
+fi
+
 log "========================================"
 
 # Cleanup ZIP (keep for cache, delete after 7 days)


### PR DESCRIPTION
## Навіщо

Міграція 183 (PR #2248) зняла фільтр по судді зі сканування 135.8 млн рядків і перевела на `edrsr_judges_distinct` — **83–120 с → 33 мс**. Але це **матеріалізоване подання**, і воно не оновлюється саме.

Отже суддя, чиє перше рішення приїхало нічною синхронізацією, лишається невидимим для фільтра, поки подання не оновлять.

⚠ **Найгірше тут — характер провалу.** Пошук по такому судді поверне «нічого не знайдено», а не помилку. Виглядатиме так, ніби у судді немає рішень, а не так, ніби щось зламано.

## Що зроблено

Крок 7 у `sync-edrsr-incremental.sh`, одразу після імпорту:

```
REFRESH MATERIALIZED VIEW CONCURRENTLY edrsr_judges_distinct;
```

`CONCURRENTLY` — щоб читачі не блокувались; для цього потрібен unique-індекс `idx_ejd_judge`, який міграція 183 і створює саме заради цього.

**Заміряно на проді: 13.1 с** на 135.8 млн рядків, 26 642 судді. Оптимізувати інкрементальністю нічого.

## Три запобіжники

Це допоміжна робота щодо імпорту, і вона **не має права завалити синхронізацію**:

| ситуація | поведінка |
|---|---|
| синхронізація не привезла нових записів | пропускається взагалі |
| подання відсутнє (міграція не застосована) | пропускається з поміткою; `resolveJudgeNames` і так відкочується на старий предикат |
| сам `REFRESH` впав | лог `WARNING`, синхронізація продовжується |

## Змін у воркфлоу не потрібно

`cron-edrsr-sync.yml` уже робить `cat` лог-файлу синхронізації, тож нові рядки — включно з `WARNING` — самі потраплять у вивід прогону.

## Перевірка

- `bash -n` — синтаксис OK
- Пробу існування перевірено на проді: `count_sql` коректно витягує `1` з виводу psql
- `REFRESH MATERIALIZED VIEW CONCURRENTLY` виконано на проді по-справжньому: 13.1 с, 26 642 рядки

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the materialized judge lookup after each EDRSR sync so new judges are searchable immediately. Prevents silent “no results” when a judge’s first decision arrives.

- **Bug Fixes**
  - Added a post-import refresh: `REFRESH MATERIALIZED VIEW CONCURRENTLY edrsr_judges_distinct` in `scripts/edrsr/sync-edrsr-incremental.sh` (uses `CONCURRENTLY`; relies on `idx_ejd_judge` from migration 183).
  - Guarded behavior: runs only when new records exist; skips if the view is absent; logs a WARNING on refresh failure and continues the sync.

<sup>Written for commit 5367f4bdbb3ff387e07059c3f35013807f8f44b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

