### PR TITLE
fix(edrsr): stop count_cases_by_party timing out on a rare party name

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -1158,7 +1158,7 @@ total_resolved_links=0 означає відсутність даних граф
         // Never let a truncated aggregate read as an exact count.
         result.capped = true;
         result.candidate_cap = counts.candidate_cap;
-        result.note += ` УВАГА: сторона має більше документів, ніж ліміт вибірки (${counts.candidate_cap}). total_cases — це НИЖНЯ МЕЖА за найновішими документами, а не точна кількість. Щоб отримати точний підрахунок, повторіть запит із date_from/date_to за коротший період (рік або два) — період звужує сам пошук, а не лише фільтрує результат.`;
+        result.note += ` УВАГА: сторона має більше документів, ніж ліміт вибірки (${counts.candidate_cap}). total_cases, courts_count і розподіл by_court пораховані ЛИШЕ за найновішими ${counts.candidate_cap} документами — це НИЖНІ МЕЖІ, а не точні значення; не подавайте жодне з них як остаточну цифру. Щоб отримати точний підрахунок, повторіть запит із date_from/date_to за коротший період (рік або два) — період звужує сам пошук, а не лише фільтрує результат.`;
       }
       if (args.date_from) result.date_from = args.date_from;
       if (args.date_to) result.date_to = args.date_to;

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -1154,6 +1154,12 @@ total_resolved_links=0 означає відсутність даних граф
         method: 'fts_party_anchor',
         note: 'Назва/роль — це FTS-прив\'язка по тексту рішення, не структурний фільтр сторони. Точне визначення ролі — після впровадження parties-таблиці (LEXAI-1760).',
       };
+      if (counts.capped) {
+        // Never let a truncated aggregate read as an exact count.
+        result.capped = true;
+        result.candidate_cap = counts.candidate_cap;
+        result.note += ` УВАГА: сторона має більше документів, ніж ліміт вибірки (${counts.candidate_cap}). total_cases — це НИЖНЯ МЕЖА за найновішими документами, а не точна кількість. Щоб отримати точний підрахунок, повторіть запит із date_from/date_to за коротший період (рік або два) — період звужує сам пошук, а не лише фільтрує результат.`;
+      }
       if (args.date_from) result.date_from = args.date_from;
       if (args.date_to) result.date_to = args.date_to;
       if (returnCases && counts.sample) {

--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -267,6 +267,27 @@ describe('EdsrFtsService.countByParty', () => {
     expect(res.candidate_cap).toBe(25000);
   });
 
+  it('still reports capped when doc-side filters drop every candidate', async () => {
+    // A doc-side filter with no CTE counterpart (justice_kind) can eliminate all of the
+    // newest candidates, leaving `agg` empty. The candidate count has to survive that,
+    // or the caller gets total 0 presented as exact while older matches exist.
+    const svc = new EdsrFtsService();
+    const db = {
+      calls: [] as any[],
+      query: jest.fn((sql: string, params: any[]) => {
+        (db as any).calls.push({ sql, params });
+        // LEFT JOIN against an empty agg: one row, candidates set, court_code null.
+        return Promise.resolve({ rows: [{ candidates: 25000, court_code: null, n: null }] });
+      }),
+    };
+    const res = await svc.countByParty('ПРИВАТБАНК', undefined, db, { justice_kind: 1 });
+
+    expect(res.by_court).toHaveLength(0);   // the synthetic row is not a court
+    expect(res.total).toBe(0);
+    expect(res.capped).toBe(true);          // ...but never an *exact* zero
+    expect(res.candidate_cap).toBe(25000);
+  });
+
   it('leaves capped unset when the party fits under the cap', async () => {
     const svc = new EdsrFtsService();
     const db = {

--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -194,6 +194,93 @@ describe('EdsrFtsService.countByParty', () => {
     expect(res.sample).toHaveLength(1);
     expect(res.sample![0].doc_id).toBe(5);
   });
+
+  /**
+   * Plan-shape guards. Each of these three details was measured on prod and each one,
+   * on its own, is the difference between ~1s and a tool timeout — none of them is
+   * visible from the result, so a refactor can drop one and only production notices.
+   */
+  it('resolves candidates in a MATERIALIZED CTE before joining edrsr_documents', async () => {
+    const svc = new EdsrFtsService();
+    const db = makeDb();
+    await svc.countByParty('ЕВЕРЛІҐАЛ', undefined, db);
+
+    const sql = db.calls[0].sql;
+    // Without MATERIALIZED the planner hash-joins a full seq scan of all 136M
+    // edrsr_documents rows (59.4s measured) instead of doing doc_id index lookups.
+    expect(sql).toContain('cand AS MATERIALIZED');
+    expect(sql).toContain('JOIN edrsr_documents d ON d.doc_id = cand.doc_id');
+  });
+
+  it('caps candidates at 25000 — a smaller cap flips the planner off the GIN scan', async () => {
+    const svc = new EdsrFtsService();
+    const db = makeDb();
+    await svc.countByParty('ЕВЕРЛІҐАЛ', undefined, db, {}, 10);
+
+    // Counter-intuitive but measured: ORDER BY doc_id DESC with LIMIT 2000 or 5000
+    // times out (>90s) where LIMIT 25000 returns in ~1.5s, because the small limit
+    // tempts the planner into walking idx_ef_p_*_docid backwards. Both paths use it.
+    for (const call of db.calls) {
+      expect(call.sql).toContain('ORDER BY f.doc_id DESC');
+      expect(call.sql).toContain('LIMIT 25000');
+    }
+    // The sample must materialize the join too, or ORDER BY adjudication_date DESC
+    // LIMIT n walks the date index probing for matches (111s measured).
+    expect(db.calls[1].sql).toContain('joined AS MATERIALIZED');
+  });
+
+  it('pushes the requested period into the CTE as an adj_year band', async () => {
+    const svc = new EdsrFtsService();
+    const db = makeDb();
+    await svc.countByParty('НАФТОГАЗ', undefined, db, { date_from: '2024-01-01', date_to: '2026-12-31' });
+
+    // With both bounds set, countByPartyFast probes edrsr_parties_coverage first, so the
+    // count is not necessarily calls[0] — pick it by shape.
+    const countCall = db.calls.find((c: any) => c.sql.includes('cand AS MATERIALIZED'));
+    if (!countCall) throw new Error('no candidate-CTE query was issued');
+    const sql = countCall.sql;
+    const params = countCall.params;
+    // edrsr_fulltext is LIST-partitioned by adj_year, so this prunes the GIN scan
+    // itself (50.5s → 1.2s). Filtering only on d.adjudication_date after the join
+    // leaves the scan just as wide, which made "narrow the period" useless advice.
+    expect(sql).toContain('f.adj_year >=');
+    expect(sql).toContain('f.adj_year <=');
+    // Band widened by a year on each side; exact bounds are still enforced on d.
+    expect(params).toContain(2023);
+    expect(params).toContain(2027);
+    expect(sql).toContain('d.adjudication_date >=');
+    expect(sql).toContain('d.adjudication_date <=');
+  });
+
+  it('flags a truncated count as capped instead of reporting a floor as exact', async () => {
+    const svc = new EdsrFtsService();
+    const db = {
+      calls: [] as any[],
+      query: jest.fn((sql: string, params: any[]) => {
+        (db as any).calls.push({ sql, params });
+        return Promise.resolve({ rows: [{ candidates: 25000, court_code: 1, n: 25000 }] });
+      }),
+    };
+    const res = await svc.countByParty('ПРИВАТБАНК', undefined, db);
+
+    expect(res.capped).toBe(true);
+    expect(res.candidate_cap).toBe(25000);
+  });
+
+  it('leaves capped unset when the party fits under the cap', async () => {
+    const svc = new EdsrFtsService();
+    const db = {
+      calls: [] as any[],
+      query: jest.fn((sql: string, params: any[]) => {
+        (db as any).calls.push({ sql, params });
+        return Promise.resolve({ rows: [{ candidates: 684, court_code: 1, n: 684 }] });
+      }),
+    };
+    const res = await svc.countByParty('ЕВЕРЛІҐАЛ', undefined, db);
+
+    expect(res.capped).toBeUndefined();
+    expect(res.total).toBe(684);
+  });
 });
 
 describe('EdsrFtsService dedicated EDRSR pool', () => {

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -1085,13 +1085,28 @@ export class EdsrFtsService {
           ${docWhere}
           GROUP BY d.court_code
         )
-        SELECT (SELECT count(*) FROM cand)::int AS candidates, court_code, n
-        FROM agg
-        ORDER BY n DESC`;
+        SELECT c.candidates, a.court_code, a.n
+        FROM (SELECT count(*)::int AS candidates FROM cand) c
+        LEFT JOIN agg a ON TRUE
+        ORDER BY a.n DESC NULLS LAST`;
       const countResult = await dbPool.query(countSql, params);
-      const by_court = countResult.rows.map((r: any) => ({ court_code: r.court_code, count: r.n }));
+      // LEFT JOIN, not `FROM agg`: the candidate count must survive an empty aggregate.
+      // A doc-side filter with no CTE counterpart (justice_kind) can drop every one of the
+      // newest candidates, and `FROM agg` would then return zero rows — losing `candidates`
+      // with them, so a capped search reported total 0 as an exact answer while older
+      // matching documents existed. That is the precise failure this method exists to stop.
+      // The synthetic row carries a null court_code and is dropped below.
+      const by_court = countResult.rows
+        .filter((r: any) => r.court_code !== null && r.court_code !== undefined)
+        .map((r: any) => ({ court_code: r.court_code, count: r.n }));
       const total = by_court.reduce((s: number, r: any) => s + r.count, 0);
       const candidates = Number(countResult.rows[0]?.candidates ?? 0);
+      // `cand` is LIMIT-ed to the cap, so count(*) over it tops out AT the cap and this is
+      // effectively `=== cap`. A party matching exactly PARTY_COUNT_CAND_CAP documents is
+      // therefore flagged capped even though its count is complete. Accepted: reading
+      // `LIMIT cap + 1` to disambiguate would perturb a planner-verified constant for one
+      // exact value, and the mislabel errs toward warning when it need not — never toward
+      // presenting a truncated count as exact, which is the direction that matters.
       const capped = candidates >= PARTY_COUNT_CAND_CAP;
 
       let sample: PartyCaseCount['sample'];

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -123,7 +123,35 @@ export interface PartyCaseCount {
   total: number;
   by_court: Array<{ court_code: number; count: number }>;
   sample?: Array<{ doc_id: number; cause_num: string | null; court_code: number | null; justice_kind: number | null; adjudication_date: string | null }>;
+  /** True when the FTS fallback hit PARTY_COUNT_CAND_CAP — `total` is then a floor, not an exact count. */
+  capped?: boolean;
+  /** The cap that was applied, present only alongside `capped`. */
+  candidate_cap?: number;
 }
+
+// Candidate cap for the countByParty FTS fallback (the path taken whenever the structured
+// parties table does not cover the requested years — i.e. always, while edrsr_parties is
+// empty on prod).
+//
+// The old query joined edrsr_fulltext to edrsr_documents directly and let the planner
+// choose. For a rare single-lexeme name the GIN row estimate is off by four orders of
+// magnitude (22.6M estimated vs 684 actual), so it hash-joined a full parallel seq scan of
+// all 136M edrsr_documents rows: 59.4s measured on prod, straddling the 60s tool timeout —
+// count_cases_by_party for "ЕВЕРЛІҐАЛ" failed 3 times out of 3. A multi-token phrase got a
+// different estimate and a nested-loop plan, which is why the same tool answered
+// "ЛУЇ ДРЕЙФУС КОМПАНІ УКРАЇНА" in 1.1s. Resolving the FTS side first (MATERIALIZED) makes
+// the join doc_id index lookups in every case: 59.4s → 1.4s for the same rare name.
+//
+// The cap bounds the mega-litigant tail (НАФТОГАЗ matches 343,089 documents, where even the
+// materialized join runs into minutes). Candidates are taken newest-first by doc_id, and a
+// truncated run sets `capped` so a floor is never reported as an exact count.
+// The same cap is used for the sample path, and it must NOT be lowered "because the sample
+// only needs ten rows". Measured on prod, sample latency for the same rare name:
+// LIMIT 2000 → >90s (timeout), LIMIT 5000 → >90s (timeout), LIMIT 25000 → 1.57s. A small
+// LIMIT makes the planner walk idx_ef_p_*_docid backwards probing tsv for matches instead of
+// running the GIN bitmap scan and sorting the top N — the bigger cap is what keeps it on the
+// index-driven plan. Same shape on a common name: 5000 → timeout, 25000 → 2.93s.
+const PARTY_COUNT_CAND_CAP = 25_000;
 
 export interface EdsrIndexProgress {
   total: number;
@@ -965,7 +993,12 @@ export class EdsrFtsService {
    * party_name is matched as a phrase (declension-tolerant for quoted proper names);
    * party_role appends the enumerated role-noun case forms. Both are anchored into the
    * tsvector match, so the GIN index does the selection and only the matched rows are
-   * counted/grouped. No LIMIT on the count — this is an exact aggregate, not a search.
+   * counted/grouped.
+   *
+   * The FTS fallback resolves candidates in a MATERIALIZED CTE capped at
+   * PARTY_COUNT_CAND_CAP before joining edrsr_documents — see that constant for the plan
+   * collapse this avoids. Below the cap the count is exact; at the cap it is a floor and
+   * `capped` is set.
    */
   async countByParty(
     partyName: string,
@@ -993,40 +1026,91 @@ export class EdsrFtsService {
       tsqueryParts.push(`to_tsquery('simple', '${roleTsquery}')`);
     }
 
-    const conditions = [`f.tsv @@ (${tsqueryParts.join(' && ')})`];
+    // Conditions are split by the table they touch: the `f` (edrsr_fulltext) ones select
+    // candidates inside the MATERIALIZED CTE, the `d` (edrsr_documents) ones filter after
+    // the join. Both share one params array, so the $-numbering stays global to the
+    // statement and must be built in this order.
+    const ftsConditions = [`f.tsv @@ (${tsqueryParts.join(' && ')})`];
     // Claim-clause role post-filter (see buildPartyRoleRegex) — keeps the count honest by
     // dropping decisions that only mention the party as a courier or in the opposite role.
     if (partyRole && partyRole !== 'any') {
-      conditions.push(`f.full_text ~* $${p}`);
+      ftsConditions.push(`f.full_text ~* $${p}`);
       params.push(buildPartyRoleRegex(partyName, partyRole));
       p++;
     }
-    if (filters.date_from) { conditions.push(`d.adjudication_date >= $${p}`); params.push(filters.date_from); p++; }
-    if (filters.date_to) { conditions.push(`d.adjudication_date <= $${p}`); params.push(filters.date_to); p++; }
-    if (filters.justice_kind) { conditions.push(`d.justice_kind = $${p}`); params.push(filters.justice_kind); p++; }
-    const whereClause = conditions.join(' AND ');
+    // Push the requested period into the CTE as an adj_year band. edrsr_fulltext is
+    // LIST-partitioned by adj_year, so this prunes partitions and shrinks the GIN scan
+    // itself — the only lever that actually helps a high-volume party. Measured on prod:
+    // НАФТОГАЗ 50.5s → 5.0s, ПРИВАТБАНК >90s → 1.8s for a single year. Without it the
+    // date filter only runs after the CTE and the "narrow the period" advice is a lie.
+    //
+    // The band is widened by a year on each side deliberately: adj_year agrees with
+    // extract(year from adjudication_date) on prod (verified, and no NULLs), but the
+    // exact d.adjudication_date bounds below are what enforce the period, so the band
+    // only ever needs to be a superset. One spare partition per side costs little and
+    // removes any timezone-boundary risk.
+    const yearBand = (iso?: string, delta = 0): number | null => {
+      const y = Number(String(iso ?? '').slice(0, 4));
+      return Number.isInteger(y) && y > 1900 ? y + delta : null;
+    };
+    const yFrom = yearBand(filters.date_from, -1);
+    const yTo = yearBand(filters.date_to, +1);
+    if (yFrom !== null) { ftsConditions.push(`f.adj_year >= $${p}`); params.push(yFrom); p++; }
+    if (yTo !== null) { ftsConditions.push(`f.adj_year <= $${p}`); params.push(yTo); p++; }
+
+    const docConditions: string[] = [];
+    if (filters.date_from) { docConditions.push(`d.adjudication_date >= $${p}`); params.push(filters.date_from); p++; }
+    if (filters.date_to) { docConditions.push(`d.adjudication_date <= $${p}`); params.push(filters.date_to); p++; }
+    if (filters.justice_kind) { docConditions.push(`d.justice_kind = $${p}`); params.push(filters.justice_kind); p++; }
+    const ftsWhere = ftsConditions.join(' AND ');
+    const docWhere = docConditions.length ? `WHERE ${docConditions.join(' AND ')}` : '';
+
+    // Candidate CTE, newest doc_id first. MATERIALIZED is load-bearing: see
+    // PARTY_COUNT_CAND_CAP for why the un-materialized join collapses.
+    const candCte = (cap: number) => `
+        cand AS MATERIALIZED (
+          SELECT f.doc_id
+          FROM edrsr_fulltext f
+          WHERE ${ftsWhere}
+          ORDER BY f.doc_id DESC
+          LIMIT ${cap}
+        )`;
 
     try {
       const countSql = `
-        SELECT d.court_code, count(*)::int AS n
-        FROM edrsr_fulltext f
-        JOIN edrsr_documents d ON d.doc_id = f.doc_id
-        WHERE ${whereClause}
-        GROUP BY d.court_code
+        WITH ${candCte(PARTY_COUNT_CAND_CAP)},
+        agg AS (
+          SELECT d.court_code, count(*)::int AS n
+          FROM cand JOIN edrsr_documents d ON d.doc_id = cand.doc_id
+          ${docWhere}
+          GROUP BY d.court_code
+        )
+        SELECT (SELECT count(*) FROM cand)::int AS candidates, court_code, n
+        FROM agg
         ORDER BY n DESC`;
       const countResult = await dbPool.query(countSql, params);
       const by_court = countResult.rows.map((r: any) => ({ court_code: r.court_code, count: r.n }));
       const total = by_court.reduce((s: number, r: any) => s + r.count, 0);
+      const candidates = Number(countResult.rows[0]?.candidates ?? 0);
+      const capped = candidates >= PARTY_COUNT_CAND_CAP;
 
       let sample: PartyCaseCount['sample'];
       if (sampleLimit > 0) {
         const safeSample = Math.min(Math.max(sampleLimit, 1), 1000);
+        // The sample only needs the newest few, so it walks a much shorter slice of the
+        // same doc_id-ordered stream. The second MATERIALIZED is also load-bearing: with
+        // a plain join the `ORDER BY adjudication_date DESC LIMIT n` lets the planner walk
+        // idx_ed_p_*_adj_date backwards probing for matches, which on a rare name means
+        // scanning millions of rows before it finds n (111s measured on prod).
         const sampleSql = `
-          SELECT d.doc_id, d.cause_num, d.court_code, d.justice_kind, d.adjudication_date
-          FROM edrsr_fulltext f
-          JOIN edrsr_documents d ON d.doc_id = f.doc_id
-          WHERE ${whereClause}
-          ORDER BY d.adjudication_date DESC NULLS LAST
+          WITH ${candCte(PARTY_COUNT_CAND_CAP)},
+          joined AS MATERIALIZED (
+            SELECT d.doc_id, d.cause_num, d.court_code, d.justice_kind, d.adjudication_date
+            FROM cand JOIN edrsr_documents d ON d.doc_id = cand.doc_id
+            ${docWhere}
+          )
+          SELECT * FROM joined
+          ORDER BY adjudication_date DESC NULLS LAST
           LIMIT ${safeSample}`;
         const sampleResult = await dbPool.query(sampleSql, params);
         sample = sampleResult.rows.map((r: any) => ({
@@ -1038,10 +1122,15 @@ export class EdsrFtsService {
       logger.info('[EdsrFtsService] countByParty', {
         party_name: partyName, party_role: partyRole ?? 'any',
         filters: Object.keys(filters).filter(k => (filters as any)[k] !== undefined),
-        total, courts: by_court.length,
+        total, courts: by_court.length, candidates, capped,
       });
 
-      return { total, by_court, ...(sample ? { sample } : {}) };
+      return {
+        total,
+        by_court,
+        ...(sample ? { sample } : {}),
+        ...(capped ? { capped: true, candidate_cap: PARTY_COUNT_CAND_CAP } : {}),
+      };
     } catch (err: any) {
       logger.error('[EdsrFtsService] countByParty failed', { error: err.message, party_name: partyName });
       throw new Error(`Party count failed: ${err.message}`);


### PR DESCRIPTION
## Why

`count_cases_by_party` failed **3 times out of 3** for `ЕВЕРЛІҐАЛ` with the 60s tool timeout. Chat then silently fell back to `search_court_decisions`, hit its 50-result cap, and answered *«Знайдено 50 судових документів у 40 унікальних справах»* — a wrong count presented as exact, with no error anywhere in the response. Real answer for the same firm is 121 cases across 30 courts.

Found while validating the EVERLEGAL demo (13 Aug) end-to-end against prod.

## Root cause

A planner collapse, not the corpus. For a rare single-lexeme name the GIN row estimate is off by four orders of magnitude — **22.6M estimated vs 684 actual** — so the old query hash-joined a full parallel seq scan of all 136M `edrsr_documents` rows:

```
Parallel Hash Join  (actual time=17625..126388 rows=684)
  ->  Parallel Append  (actual rows=136050602)
        ->  Parallel Seq Scan on edrsr_documents_p_2011 ...
        ->  Parallel Seq Scan on edrsr_documents_p_2025 ...
        ... all 25 partitions
```

A multi-token phrase got a different estimate and a nested-loop plan, which is why the same tool answered `ЛУЇ ДРЕЙФУС КОМПАНІ УКРАЇНА` in 1.1s. That is the whole difference between the two.

## Changes

| | |
|---|---|
| Candidates resolved in a `MATERIALIZED` CTE before the join | join becomes `doc_id` index lookups |
| Requested period pushed into the CTE as an `adj_year` band | `edrsr_fulltext` is LIST-partitioned by `adj_year`, so this prunes the GIN scan itself |
| Join materialized in the sample path too | stops `ORDER BY adjudication_date DESC LIMIT n` walking the date index probing for matches |
| `capped` flag + explicit Ukrainian warning in the tool note | a truncated count is never relayed as exact |

## Measured on prod (generated SQL, not a proxy)

| Scenario | Before | After |
|---|---|---|
| `ЕВЕРЛІҐАЛ`, no filters | 59.4s / timeout 3-of-3 | **1.32s** (684 docs, 177 courts) |
| sample path, rare name | 111s | **1.62s** |
| `ЛУЇ ДРЕЙФУС КОМПАНІ УКРАЇНА` (regression check) | 1.1s | **1.92s** (1341/77) |
| `НАФТОГАЗ` 2024–2026 | 120s | **1.22s** |
| role regex in CTE | — | 2.15s |
| zero-match party | — | 1.34s, `candidates=0` |

## The cap is 25000 and must not be lowered

Counter-intuitive, so it is pinned by a test. Sample-path latency for the same name:

| cap | result |
|---|---|
| 2000 | >90s timeout |
| 5000 | >90s timeout |
| 25000 | **1.57s** |

A small `LIMIT` tempts the planner into walking `idx_ef_p_*_docid` backwards instead of running the GIN bitmap scan and sorting the top N. My first draft used 2000 for the sample "because it only needs ten rows" — that would have been a regression, and only the measurement caught it.

## Known limitation, not fixed

A party matching hundreds of thousands of documents with **no period given** (`ПРИВАТБАНК`) still exceeds the tool timeout. With a period it is ~1.8s, and the `capped` note now tells the model to narrow the period — advice that is only true because of the `adj_year` pushdown in this PR.

## Deliberately not changed

The legal-form prefix strip (`ТОВ`/`ПАТ`/`ФОП`). I had planned to remove it, then reconsidered: courts write «Товариство з обмеженою відповідальністю "X"», so stripping is what makes the phrase match — removing it would cost recall. The plan, not the strip, is what made single-token names slow.

## Tests

5 new plan-shape guards in `edrsr-fts-service.test.ts` (MATERIALIZED present, cap value, `adj_year` pushdown, `capped` set/unset). 51/51 pass in the two FTS suites. `tsc --noEmit` clean — the 6 remaining errors are pre-existing on `main` and in other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `count_cases_by_party` timeouts on rare single-word party names and prevents wrong exact zeros when doc-side filters empty the aggregate. Typical queries now return in ~1–2s, and truncated totals are never shown as exact.

- **Bug Fixes**
  - Reshape the plan: resolve FTS candidates in a MATERIALIZED CTE and join by `doc_id`; push `adj_year` into the CTE; materialize the sample join to avoid index walking.
  - Cap candidates at 25,000 for count and sample; return `capped`/`candidate_cap`; tool note now warns that `total_cases`, `courts_count`, and `by_court` are lower bounds when capped, with advice to narrow the period.
  - Keep the candidate count when doc-side filters (e.g. `justice_kind`) drop all newest matches by `LEFT JOIN`-ing the aggregate; prevents reporting an exact zero under a cap. Add plan-shape tests for `MATERIALIZED`, the 25k cap, `adj_year` pushdown, capped/unset behavior, and the empty-aggregate case.

<sup>Written for commit 3494d7e45b0584adbe121be98663b27dec1053a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

