### PR TITLE
fix(edrsr): answer high-volume parties instead of timing out on the sort

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -1158,7 +1158,7 @@ total_resolved_links=0 означає відсутність даних граф
         // Never let a truncated aggregate read as an exact count.
         result.capped = true;
         result.candidate_cap = counts.candidate_cap;
-        result.note += ` УВАГА: сторона має більше документів, ніж ліміт вибірки (${counts.candidate_cap}). total_cases, courts_count і розподіл by_court пораховані ЛИШЕ за вибіркою з ${counts.candidate_cap} документів за останні роки — це НИЖНІ МЕЖІ, а не точні значення, і розподіл по судах теж зміщений до свіжої практики; не подавайте жодне з них як остаточну цифру. Щоб отримати точний підрахунок, повторіть запит із date_from/date_to за коротший період (рік або два) — період звужує сам пошук, а не лише фільтрує результат.`;
+        result.note += ` УВАГА: сторона має більше документів, ніж ліміт вибірки (${counts.candidate_cap}). total_cases, courts_count і розподіл by_court пораховані ЛИШЕ за ${counts.candidate_cap} НАЙНОВІШИМИ документами — це НИЖНІ МЕЖІ, а не точні значення, і розподіл по судах відображає свіжу практику, а не всю історію сторони; не подавайте жодне з них як остаточну цифру. Щоб отримати точний підрахунок, повторіть запит із date_from/date_to за коротший період (рік або два) — період звужує сам пошук, а не лише фільтрує результат.`;
       }
       if (args.date_from) result.date_from = args.date_from;
       if (args.date_to) result.date_to = args.date_to;

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -1158,7 +1158,7 @@ total_resolved_links=0 означає відсутність даних граф
         // Never let a truncated aggregate read as an exact count.
         result.capped = true;
         result.candidate_cap = counts.candidate_cap;
-        result.note += ` УВАГА: сторона має більше документів, ніж ліміт вибірки (${counts.candidate_cap}). total_cases, courts_count і розподіл by_court пораховані ЛИШЕ за найновішими ${counts.candidate_cap} документами — це НИЖНІ МЕЖІ, а не точні значення; не подавайте жодне з них як остаточну цифру. Щоб отримати точний підрахунок, повторіть запит із date_from/date_to за коротший період (рік або два) — період звужує сам пошук, а не лише фільтрує результат.`;
+        result.note += ` УВАГА: сторона має більше документів, ніж ліміт вибірки (${counts.candidate_cap}). total_cases, courts_count і розподіл by_court пораховані ЛИШЕ за вибіркою з ${counts.candidate_cap} документів за останні роки — це НИЖНІ МЕЖІ, а не точні значення, і розподіл по судах теж зміщений до свіжої практики; не подавайте жодне з них як остаточну цифру. Щоб отримати точний підрахунок, повторіть запит із date_from/date_to за коротший період (рік або два) — період звужує сам пошук, а не лише фільтрує результат.`;
       }
       if (args.date_from) result.date_from = args.date_from;
       if (args.date_to) result.date_to = args.date_to;

--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -224,10 +224,9 @@ describe('EdsrFtsService.countByParty', () => {
       expect(call.sql).toContain('ORDER BY f.doc_id DESC');
       expect(call.sql).toContain('LIMIT 25000');
     }
-    // ...and the ordering must appear ONLY on the older leg. Sorting the recent band is
-    // what made a 400k-document party unanswerable, so exactly one ORDER BY on doc_id.
+    // One ORDER BY per candidate leg — see the three-leg test for why each leg keeps it.
     for (const call of db.calls) {
-      expect(call.sql.match(/ORDER BY f\.doc_id DESC/g)).toHaveLength(1);
+      expect(call.sql.match(/ORDER BY f\.doc_id DESC/g)).toHaveLength(3);
     }
     // The sample must materialize the join too, or ORDER BY adjudication_date DESC
     // LIMIT n walks the date index probing for matches (111s measured).
@@ -272,26 +271,30 @@ describe('EdsrFtsService.countByParty', () => {
     expect(res.candidate_cap).toBe(25000);
   });
 
-  it('splits candidates into an unsorted recent band and an ordered older remainder', async () => {
+  it('takes candidates newest-year-first across three ordered legs', async () => {
     const svc = new EdsrFtsService();
     const db = makeDb();
     await svc.countByParty('ПРИВАТБАНК', undefined, db);
 
     const sql = db.calls[0].sql;
-    // The recent band carries the year predicate and no sort — that is the whole fix for
-    // a party matching hundreds of thousands of documents (>90s timeout -> 2.26s).
-    expect(sql).toContain('recent AS MATERIALIZED');
-    expect(sql).toContain('f.adj_year >=');
+    // Per-year legs are the whole fix: each prunes to one partition, so it sorts only that
+    // partition instead of the corpus (>90s timeout -> 2.41s for a 400k-document party).
+    expect(sql).toContain('r0 AS MATERIALIZED');
+    expect(sql).toContain('r1 AS MATERIALIZED');
     expect(sql).toContain('older AS MATERIALIZED');
-    expect(sql).toContain('f.adj_year <');
-    // The older leg's limit is whatever the recent band left unfilled, so a party that
-    // already reached the cap gets LIMIT 0 and Postgres skips the ordered scan entirely.
-    expect(sql).toContain('GREATEST(0, 25000 - (SELECT count(*) FROM recent))');
-    // Both legs feed one candidate set; the legs are disjoint so nothing is double counted.
-    expect(sql).toContain('SELECT doc_id FROM recent');
-    expect(sql).toContain('UNION ALL');
+    // Every leg stays ordered. Dropping the sort on the recent leg is faster still, but it
+    // returns physical heap order, so a capped party's "newest" decisions were whatever the
+    // scan hit first — measured as a sample topping out at 2025-12-31 while the corpus ran
+    // to 2026-07-13. Ordering every leg is what makes the union exactly the newest N.
+    expect(sql.match(/ORDER BY f\.doc_id DESC/g)).toHaveLength(3);
+    // Each later leg only takes what its predecessors left; at 0 Postgres skips the scan.
+    expect(sql).toContain('GREATEST(0, 25000 - (SELECT count(*) FROM r0))');
+    expect(sql).toContain('GREATEST(0, 25000 - (SELECT count(*) FROM r0) - (SELECT count(*) FROM r1))');
+    expect(sql).toContain('SELECT doc_id FROM r0');
+    expect(sql).toContain('SELECT doc_id FROM r1');
     expect(sql).toContain('SELECT doc_id FROM older');
-    // Split year is bound, never interpolated.
+    // Year boundaries are bound, never interpolated.
+    expect(db.calls[0].params).toContain(new Date().getFullYear());
     expect(db.calls[0].params).toContain(new Date().getFullYear() - 1);
   });
 

--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -217,12 +217,17 @@ describe('EdsrFtsService.countByParty', () => {
     const db = makeDb();
     await svc.countByParty('ЕВЕРЛІҐАЛ', undefined, db, {}, 10);
 
-    // Counter-intuitive but measured: ORDER BY doc_id DESC with LIMIT 2000 or 5000
-    // times out (>90s) where LIMIT 25000 returns in ~1.5s, because the small limit
-    // tempts the planner into walking idx_ef_p_*_docid backwards. Both paths use it.
+    // Counter-intuitive but measured: on the ordered leg, LIMIT 2000 or 5000 times out
+    // (>90s) where LIMIT 25000 returns in ~1.5s, because the small limit tempts the
+    // planner into walking idx_ef_p_*_docid backwards. Both paths use the same cap.
     for (const call of db.calls) {
       expect(call.sql).toContain('ORDER BY f.doc_id DESC');
       expect(call.sql).toContain('LIMIT 25000');
+    }
+    // ...and the ordering must appear ONLY on the older leg. Sorting the recent band is
+    // what made a 400k-document party unanswerable, so exactly one ORDER BY on doc_id.
+    for (const call of db.calls) {
+      expect(call.sql.match(/ORDER BY f\.doc_id DESC/g)).toHaveLength(1);
     }
     // The sample must materialize the join too, or ORDER BY adjudication_date DESC
     // LIMIT n walks the date index probing for matches (111s measured).
@@ -265,6 +270,29 @@ describe('EdsrFtsService.countByParty', () => {
 
     expect(res.capped).toBe(true);
     expect(res.candidate_cap).toBe(25000);
+  });
+
+  it('splits candidates into an unsorted recent band and an ordered older remainder', async () => {
+    const svc = new EdsrFtsService();
+    const db = makeDb();
+    await svc.countByParty('ПРИВАТБАНК', undefined, db);
+
+    const sql = db.calls[0].sql;
+    // The recent band carries the year predicate and no sort — that is the whole fix for
+    // a party matching hundreds of thousands of documents (>90s timeout -> 2.26s).
+    expect(sql).toContain('recent AS MATERIALIZED');
+    expect(sql).toContain('f.adj_year >=');
+    expect(sql).toContain('older AS MATERIALIZED');
+    expect(sql).toContain('f.adj_year <');
+    // The older leg's limit is whatever the recent band left unfilled, so a party that
+    // already reached the cap gets LIMIT 0 and Postgres skips the ordered scan entirely.
+    expect(sql).toContain('GREATEST(0, 25000 - (SELECT count(*) FROM recent))');
+    // Both legs feed one candidate set; the legs are disjoint so nothing is double counted.
+    expect(sql).toContain('SELECT doc_id FROM recent');
+    expect(sql).toContain('UNION ALL');
+    expect(sql).toContain('SELECT doc_id FROM older');
+    // Split year is bound, never interpolated.
+    expect(db.calls[0].params).toContain(new Date().getFullYear() - 1);
   });
 
   it('still reports capped when doc-side filters drop every candidate', async () => {

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -142,9 +142,13 @@ export interface PartyCaseCount {
 // "ЛУЇ ДРЕЙФУС КОМПАНІ УКРАЇНА" in 1.1s. Resolving the FTS side first (MATERIALIZED) makes
 // the join doc_id index lookups in every case: 59.4s → 1.4s for the same rare name.
 //
-// The cap bounds the mega-litigant tail (НАФТОГАЗ matches 343,089 documents, where even the
-// materialized join runs into minutes). Candidates are taken newest-first by doc_id, and a
-// truncated run sets `capped` so a floor is never reported as an exact count.
+// The cap bounds the high-volume tail (НАФТОГАЗ matches 343,089 documents, ПРИВАТБАНК more
+// than 400,000, where even the materialized join runs into minutes). A truncated run sets
+// `capped` so a floor is never reported as an exact count. How the capped subset is chosen
+// differs by leg — see candCte: the ordered "newest first" rule holds for parties that fit
+// inside the cap, while a party that overflows it is answered from the recent year band
+// without a global sort, because the sort was the thing that made it unanswerable.
+//
 // The same cap is used for the sample path, and it must NOT be lowered "because the sample
 // only needs ten rows". Measured on prod, sample latency for the same rare name:
 // LIMIT 2000 → >90s (timeout), LIMIT 5000 → >90s (timeout), LIMIT 25000 → 1.57s. A small
@@ -1065,15 +1069,59 @@ export class EdsrFtsService {
     const ftsWhere = ftsConditions.join(' AND ');
     const docWhere = docConditions.length ? `WHERE ${docConditions.join(' AND ')}` : '';
 
-    // Candidate CTE, newest doc_id first. MATERIALIZED is load-bearing: see
+    // Split point between the "recent" and "older" candidate legs (see candCte). Two years
+    // rather than one: a single-year band would be nearly empty each January, so a
+    // high-volume party would stop filling its cap from `recent` and fall back onto the
+    // expensive ordered leg for a few weeks a year.
+    const recentFromYear = new Date().getFullYear() - 1;
+    const splitParam = p; params.push(recentFromYear); p++;
+
+    // Candidates, in two disjoint legs. MATERIALIZED is load-bearing throughout: see
     // PARTY_COUNT_CAND_CAP for why the un-materialized join collapses.
+    //
+    // `recent` deliberately has NO ORDER BY. Sorting is what made a high-volume party
+    // unanswerable: picking "the newest 25000" globally forces the GIN scan to read every
+    // match first, so ПРИВАТБАНК (400k+ documents) blew past 90s. The year band already
+    // guarantees recency, which is all the ordering was buying, so without it the bitmap
+    // scan simply stops once the cap is full — the same query drops to 2-4s.
+    //
+    // `older` keeps ORDER BY, because it genuinely has to pick the newest of what remains,
+    // and its LIMIT is whatever `recent` left unfilled. When `recent` already reached the
+    // cap that expression is 0 and Postgres skips the leg without scanning, so a
+    // high-volume party never pays for the ordered path at all. The legs are disjoint, so
+    // for everyone else the total work is the same rows as a single scan, split in two.
+    //
+    // Cost of the split, measured on prod, paired and cache-fair: a rare name pays one
+    // extra band scan (ЕВЕРЛІҐАЛ 1.18s -> 1.63s) and a mid-volume one pays nothing
+    // (ЛУЇ ДРЕЙФУС 0.26s both ways). That buys ПРИВАТБАНК going from a hard timeout —
+    // which the model then relayed as a confident wrong count — to 2.26s.
+    //
+    // Consequence to keep in mind for the sample: a party that fills its cap from `recent`
+    // is answered from that band in partition order, so its newest returned decision is
+    // the newest of the FIRST year in the band, not of the corpus (ПРИВАТБАНК sampled
+    // 2025-12-31 while a sub-cap party sampled 2026-07-06). Only capped parties are
+    // affected — anything under the cap still comes back strictly newest-first through the
+    // ordered leg — and `capped` plus its note tell the caller the subset is recent-years,
+    // not latest. Narrowing the band to one year would restore exact recency but reopens
+    // the timeout every January, when that partition is too thin to fill the cap.
     const candCte = (cap: number) => `
-        cand AS MATERIALIZED (
+        recent AS MATERIALIZED (
           SELECT f.doc_id
           FROM edrsr_fulltext f
-          WHERE ${ftsWhere}
-          ORDER BY f.doc_id DESC
+          WHERE ${ftsWhere} AND f.adj_year >= $${splitParam}
           LIMIT ${cap}
+        ),
+        older AS MATERIALIZED (
+          SELECT f.doc_id
+          FROM edrsr_fulltext f
+          WHERE ${ftsWhere} AND f.adj_year < $${splitParam}
+          ORDER BY f.doc_id DESC
+          LIMIT GREATEST(0, ${cap} - (SELECT count(*) FROM recent))
+        ),
+        cand AS MATERIALIZED (
+          SELECT doc_id FROM recent
+          UNION ALL
+          SELECT doc_id FROM older
         )`;
 
     try {

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -143,11 +143,11 @@ export interface PartyCaseCount {
 // the join doc_id index lookups in every case: 59.4s → 1.4s for the same rare name.
 //
 // The cap bounds the high-volume tail (НАФТОГАЗ matches 343,089 documents, ПРИВАТБАНК more
-// than 400,000, where even the materialized join runs into minutes). A truncated run sets
-// `capped` so a floor is never reported as an exact count. How the capped subset is chosen
-// differs by leg — see candCte: the ordered "newest first" rule holds for parties that fit
-// inside the cap, while a party that overflows it is answered from the recent year band
-// without a global sort, because the sort was the thing that made it unanswerable.
+// than 400,000, where even the materialized join runs into minutes). The capped subset is
+// always the NEWEST `cap` documents — candCte assembles it from per-year legs precisely so
+// that stays true without a corpus-wide sort. A truncated run sets `capped`, so a floor is
+// never reported as an exact count; note that by_court is then a distribution over those
+// newest documents, not over the party's whole history.
 //
 // The same cap is used for the sample path, and it must NOT be lowered "because the sample
 // only needs ten rows". Measured on prod, sample latency for the same rare name:
@@ -1069,57 +1069,70 @@ export class EdsrFtsService {
     const ftsWhere = ftsConditions.join(' AND ');
     const docWhere = docConditions.length ? `WHERE ${docConditions.join(' AND ')}` : '';
 
-    // Split point between the "recent" and "older" candidate legs (see candCte). Two years
-    // rather than one: a single-year band would be nearly empty each January, so a
-    // high-volume party would stop filling its cap from `recent` and fall back onto the
-    // expensive ordered leg for a few weeks a year.
-    const recentFromYear = new Date().getFullYear() - 1;
-    const splitParam = p; params.push(recentFromYear); p++;
+    // Year boundaries between the three candidate legs (see candCte). Two single-year legs
+    // ahead of the remainder, rather than one two-year band: each is pruned to a single
+    // partition, which is what keeps its sort cheap, and the second one carries a
+    // high-volume party through January, when the current-year partition is still too thin
+    // to fill the cap on its own.
+    const thisYear = new Date().getFullYear();
+    const y0Param = p; params.push(thisYear); p++;
+    const y1Param = p; params.push(thisYear - 1); p++;
 
-    // Candidates, in two disjoint legs. MATERIALIZED is load-bearing throughout: see
-    // PARTY_COUNT_CAND_CAP for why the un-materialized join collapses.
+    // Candidates, in three disjoint legs taken newest year first. MATERIALIZED is
+    // load-bearing throughout: see PARTY_COUNT_CAND_CAP for why the un-materialized join
+    // collapses.
     //
-    // `recent` deliberately has NO ORDER BY. Sorting is what made a high-volume party
-    // unanswerable: picking "the newest 25000" globally forces the GIN scan to read every
-    // match first, so ПРИВАТБАНК (400k+ documents) blew past 90s. The year band already
-    // guarantees recency, which is all the ordering was buying, so without it the bitmap
-    // scan simply stops once the cap is full — the same query drops to 2-4s.
+    // The problem this shape solves is that "the newest 25000" as ONE global top-N forces
+    // the GIN scan to read every match before it can answer, so a party with hundreds of
+    // thousands of documents was unanswerable: ПРИВАТБАНК (400k+) ran past 90s and blew
+    // the 60s tool timeout. Splitting by year fixes it without giving up the ordering,
+    // because each leg is pruned to a single partition and sorts only that partition:
+    // `r0` alone satisfies a high-volume party and the rest are skipped.
     //
-    // `older` keeps ORDER BY, because it genuinely has to pick the newest of what remains,
-    // and its LIMIT is whatever `recent` left unfilled. When `recent` already reached the
-    // cap that expression is 0 and Postgres skips the leg without scanning, so a
-    // high-volume party never pays for the ordered path at all. The legs are disjoint, so
-    // for everyone else the total work is the same rows as a single scan, split in two.
+    // Every leg after the first is limited to whatever its predecessors left unfilled.
+    // When the cap is already full that expression is 0 and Postgres returns from the leg
+    // without scanning it, which is what makes the skip free. Because the legs are
+    // disjoint and consumed in descending year order, the union is EXACTLY the newest
+    // `cap` documents — the same answer a global ORDER BY would give, assembled from
+    // partition-local sorts instead of one corpus-wide one.
     //
-    // Cost of the split, measured on prod, paired and cache-fair: a rare name pays one
-    // extra band scan (ЕВЕРЛІҐАЛ 1.18s -> 1.63s) and a mid-volume one pays nothing
-    // (ЛУЇ ДРЕЙФУС 0.26s both ways). That buys ПРИВАТБАНК going from a hard timeout —
-    // which the model then relayed as a confident wrong count — to 2.26s.
+    // Measured on prod, paired and cache-fair. High-volume parties become answerable:
+    // ПРИВАТБАНК >90s timeout -> 2.41s count / 2.72s sample, НАФТОГАЗ 50.5s -> 2.50s, and
+    // both sample the true corpus maximum (2026-07-13). The price is one extra leg scan
+    // for a rare name (ЕВЕРЛІҐАЛ 1.18s -> 1.66s) and nothing for a mid-volume one
+    // (ЛУЇ ДРЕЙФУС 0.26s either way).
     //
-    // Consequence to keep in mind for the sample: a party that fills its cap from `recent`
-    // is answered from that band in partition order, so its newest returned decision is
-    // the newest of the FIRST year in the band, not of the corpus (ПРИВАТБАНК sampled
-    // 2025-12-31 while a sub-cap party sampled 2026-07-06). Only capped parties are
-    // affected — anything under the cap still comes back strictly newest-first through the
-    // ordered leg — and `capped` plus its note tell the caller the subset is recent-years,
-    // not latest. Narrowing the band to one year would restore exact recency but reopens
-    // the timeout every January, when that partition is too thin to fill the cap.
+    // Two single-year legs rather than one two-year band, for two independent reasons.
+    // Cost: ordering a two-year band costs 44s cold for ПРИВАТБАНК versus 2.4s for a
+    // single year. Calendar: a lone current-year leg is too thin every January to fill the
+    // cap, which would drop high-volume parties back onto the corpus-wide ordered leg for
+    // weeks — verified by running the split a year ahead (2.44s, still fine).
     const candCte = (cap: number) => `
-        recent AS MATERIALIZED (
+        r0 AS MATERIALIZED (
           SELECT f.doc_id
           FROM edrsr_fulltext f
-          WHERE ${ftsWhere} AND f.adj_year >= $${splitParam}
+          WHERE ${ftsWhere} AND f.adj_year >= $${y0Param}
+          ORDER BY f.doc_id DESC
           LIMIT ${cap}
+        ),
+        r1 AS MATERIALIZED (
+          SELECT f.doc_id
+          FROM edrsr_fulltext f
+          WHERE ${ftsWhere} AND f.adj_year >= $${y1Param} AND f.adj_year < $${y0Param}
+          ORDER BY f.doc_id DESC
+          LIMIT GREATEST(0, ${cap} - (SELECT count(*) FROM r0))
         ),
         older AS MATERIALIZED (
           SELECT f.doc_id
           FROM edrsr_fulltext f
-          WHERE ${ftsWhere} AND f.adj_year < $${splitParam}
+          WHERE ${ftsWhere} AND f.adj_year < $${y1Param}
           ORDER BY f.doc_id DESC
-          LIMIT GREATEST(0, ${cap} - (SELECT count(*) FROM recent))
+          LIMIT GREATEST(0, ${cap} - (SELECT count(*) FROM r0) - (SELECT count(*) FROM r1))
         ),
         cand AS MATERIALIZED (
-          SELECT doc_id FROM recent
+          SELECT doc_id FROM r0
+          UNION ALL
+          SELECT doc_id FROM r1
           UNION ALL
           SELECT doc_id FROM older
         )`;


### PR DESCRIPTION
Follow-up to #2250, which left this open explicitly: a party matching hundreds of thousands of documents **with no period given** still blew the 60s tool timeout. `ПРИВАТБАНК` (400k+ matches) ran past 90s, so `count_cases_by_party` failed and chat fell back to relaying a search cap as if it were a count — the exact failure #2250 set out to remove.

## The cost was the sort, not the volume

"Newest 25000" is a global top-N, so the GIN scan must read **every** match before it can answer. Measured on prod for the same term:

| same scan | time |
|---|---|
| `ORDER BY doc_id DESC LIMIT 25000` | >90s |
| bare `LIMIT 25001`, no ORDER BY | **0.24s** |

The bitmap scan stops as soon as the cap is full. Sorting is the entire difference — but dropping it globally is not an option, because partition order runs oldest-first and the sample would come back from 2005.

## Two disjoint legs

- **`recent`** — last two years, bare `LIMIT`, **no ORDER BY**. The year band already guarantees recency, which is all the sort was buying. A high-volume party fills its cap here and stops.
- **`older`** — everything before that, still ordered (it genuinely has to pick the newest of what remains), limited to `GREATEST(0, cap - (SELECT count(*) FROM recent))`. When the cap is already full that is `LIMIT 0` and Postgres skips the leg without scanning, so a high-volume party never pays for the ordered path at all.

Two years rather than one: a single-year band is nearly empty each January, which would drop high-volume parties back onto the ordered leg for weeks at a time.

## Measured on prod (generated SQL)

| | before | after |
|---|---|---|
| `ПРИВАТБАНК` count | >90s timeout | **2.26s** |
| `ПРИВАТБАНК` sample | >90s timeout | **2.65s** |
| `НАФТОГАЗ` count | 50.5s | **2.25s** |
| `ЕВЕРЛІҐАЛ` count (regression) | 1.18s | 1.66s |
| `ЛУЇ ДРЕЙФУС` count (regression) | 0.27s | **0.27s** |

Counts unchanged: `ЕВЕРЛІҐАЛ` 684, `ЛУЇ ДРЕЙФУС` 1341. The rare-name cost is one extra band scan; I took it deliberately — 0.48s against a 60s tool budget, in exchange for a whole class of parties going from "wrong answer delivered confidently" to answerable.

Edges re-verified: a period entirely before the split year prunes `recent` to nothing (0.57s, correct 0 — confirmed `ЕВЕРЛІҐАЛ` genuinely has no 2009–2014 documents, so it is not a split artifact); a doc-side filter that drops every candidate still reports `candidates=684` with `capped`; an unmatched party still returns an honest zero.

## Documented consequence

A capped party's sample comes from the band in partition order, so its newest returned decision is the newest of the **first year in the band** (`ПРИВАТБАНК` → 2025-12-31) rather than of the corpus (a sub-cap party → 2026-07-06). Only capped parties are affected — anything under the cap still comes back strictly newest-first through the ordered leg. The Ukrainian note now says the subset is recent-years and that the by-court breakdown is skewed toward recent practice, instead of implying either is exact.

Narrowing the band to one year would restore exact recency but reopens the timeout every January. That tradeoff is written down at the call site.

## Tests

New guard pins the split shape: year predicate on both legs, no sort on `recent`, exactly one `ORDER BY f.doc_id DESC` across the statement, the `GREATEST(0, …)` limit, the `UNION ALL`, and the split year bound rather than interpolated. 53/53 pass. `tsc` adds no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sort-induced timeouts for high‑volume parties by taking candidates in three ordered legs (this year, last year, older) so a capped subset is exactly the newest N without a corpus‑wide sort. Also updates the capped note to say results cover the newest documents and that by‑court reflects recent practice.

- **Bug Fixes**
  - Candidates now come from three MATERIALIZED legs (`r0`, `r1`, `older`), each `ORDER BY f.doc_id DESC`; later legs use `LIMIT GREATEST(0, cap - prior counts)`, then `UNION ALL`.
  - Performance: >90s → ~2.4s counts / ~2.7s samples for mega litigants; rare names pay a small extra leg scan; counts unchanged.
  - Tests pin the shape: bound year params for current and previous year, three `ORDER BY f.doc_id DESC`, MATERIALIZED join for sampling, and cap stability.
  - Note text clarifies the figures cover the newest N documents and that `by_court` reflects recent practice, not full history.

<sup>Written for commit 55f7aac86949f9d5e891071c75a6bc1faf86de53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

