### PR TITLE
fix(edrsr): resolve the procedural suffix in a case number

### DIFF
--- a/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
+++ b/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
@@ -91,6 +91,30 @@ describe('resolveCauseNumber', () => {
     expect(res.matches.map((m) => m.cause_num)).toEqual(['123/456/20-ц', '123/456/20-а']);
   });
 
+  it('never swaps a suffix the caller actually typed for a different one', async () => {
+    // Regression guard. Widening the variations regex to accept multi-letter suffixes made
+    // it strip unmeasured ones too, so 905/1234/20-XYZ decayed to 905/1234/20, picked the
+    // measured suffixes up as candidates, and would have resolved to 905/1234/20-ц — a
+    // different real case answered as though it were the one asked about.
+    const db = makeDb([{ cause_num: '905/1234/20-ц', member_count: 30 }]);
+    const res = await resolveCauseNumber('905/1234/20-XYZ', db);
+
+    expect(res.resolved).toBeNull();
+    expect(res.ambiguous).toBe(false);
+
+    // Same rule for a measured suffix that simply does not exist: -а must not become -ц.
+    const db2 = makeDb([{ cause_num: '905/1234/20-ц', member_count: 30 }]);
+    expect((await resolveCauseNumber('905/1234/20-а', db2)).resolved).toBeNull();
+  });
+
+  it('still completes a missing suffix and honours year expansion within one suffix', async () => {
+    const db = makeDb([{ cause_num: '905/1234/2020-ад', member_count: 5 }]);
+    const res = await resolveCauseNumber('905/1234/20-ад', db);
+
+    // Same suffix, different year spelling — allowed, because the suffix is not being swapped.
+    expect(res.resolved).toBe('905/1234/2020-ад');
+  });
+
   it('resolves to nothing when the number matches no case at all', async () => {
     const res = await resolveCauseNumber('999/999/99', makeDb([]));
 

--- a/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
+++ b/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
@@ -32,6 +32,15 @@ describe('generateCaseNumberCandidates', () => {
     expect(candidates).toContain('369/6892/2015-ц');  // combined with year expansion
   });
 
+  it('expands the year for multi-letter suffixes too', () => {
+    // The variations regex used to match a single suffix character, so ад/НМ/НА/НР/АП
+    // failed the pattern outright and got no year expansion at all.
+    const candidates = generateCaseNumberCandidates('905/1234/20-ад');
+
+    expect(candidates).toContain('905/1234/20-ад');
+    expect(candidates).toContain('905/1234/2020-ад');
+  });
+
   it('does not pile suffixes onto a number that already has one', () => {
     const candidates = generateCaseNumberCandidates('369/6892/15-ц');
 

--- a/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
+++ b/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
@@ -115,6 +115,16 @@ describe('resolveCauseNumber', () => {
     expect(res.resolved).toBe('905/1234/2020-ад');
   });
 
+  it('still rewrites a legacy VSU number to its canonical slash spelling', async () => {
+    // The suffix guard must not read the hyphen inside a pre-2017 Supreme Court identifier
+    // as a caller-chosen suffix: "5-15кс12" would then never match "5-15/12", which has no
+    // suffix at all, and the guard would block the very rewrite the VSU branch exists for.
+    const db = makeDb([{ cause_num: '5-15/12', member_count: 6 }]);
+    const res = await resolveCauseNumber('5-15кс12', db);
+
+    expect(res.resolved).toBe('5-15/12');
+  });
+
   it('resolves to nothing when the number matches no case at all', async () => {
     const res = await resolveCauseNumber('999/999/99', makeDb([]));
 

--- a/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
+++ b/mcp_backend/src/api/__tests__/resolve-cause-number.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Case-number suffix resolution.
+ *
+ * The chat model strips the procedural suffix on its way to a tool — it was asked about
+ * 369/6892/15-ц and called check_precedent_status with 369/6892/15. The bare number matches
+ * no cause_num, so shepardization returned `unknown` (0.5) rather than explicitly_overruled
+ * (0.95) and the answer read "справу не знайдено в ЄДРСР": a confident false negative on
+ * the question the tool exists to answer. External MCP v2 clients hit the same path.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { generateCaseNumberCandidates, resolveCauseNumber } from '../tool-utils';
+
+const makeDb = (rows: Array<{ cause_num: string; member_count: number }>) => {
+  const calls: { sql: string; params: any[] }[] = [];
+  return {
+    calls,
+    query: jest.fn((sql: string, params: any[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve({ rows });
+    }),
+  };
+};
+
+describe('generateCaseNumberCandidates', () => {
+  it('adds suffixed spellings that generateCaseNumberVariations never produces', () => {
+    const candidates = generateCaseNumberCandidates('369/6892/15');
+
+    expect(candidates).toContain('369/6892/15');      // the input itself
+    expect(candidates).toContain('369/6892/15-ц');    // the spelling EDRSR actually stores
+    expect(candidates).toContain('369/6892/15-а');
+    expect(candidates).toContain('369/6892/2015-ц');  // combined with year expansion
+  });
+
+  it('does not pile suffixes onto a number that already has one', () => {
+    const candidates = generateCaseNumberCandidates('369/6892/15-ц');
+
+    expect(candidates).toContain('369/6892/15-ц');
+    expect(candidates.some((c) => /-ц-/.test(c))).toBe(false);
+    // Stripping stays available — that direction already worked.
+    expect(candidates).toContain('369/6892/15');
+  });
+});
+
+describe('resolveCauseNumber', () => {
+  it('rewrites a suffix-stripped number to the one case that exists', async () => {
+    const db = makeDb([{ cause_num: '369/6892/15-ц', member_count: 40 }]);
+    const res = await resolveCauseNumber('369/6892/15', db);
+
+    expect(res.resolved).toBe('369/6892/15-ц');
+    expect(res.ambiguous).toBe(false);
+    // Equality against the cause_num primary key, not a prefix LIKE: the database
+    // collation is en_US.utf8, where LIKE 'base%' cannot use that index and seq-scans
+    // (5.2s measured on prod, against 1.7ms for this form).
+    expect(db.calls[0].sql).toContain('cause_num = ANY($1::text[])');
+    expect(db.calls[0].sql).not.toContain('LIKE');
+  });
+
+  it('keeps the caller spelling when it exists, even alongside other suffixes', async () => {
+    const db = makeDb([
+      { cause_num: '910/3134/22-ц', member_count: 90 },
+      { cause_num: '910/3134/22', member_count: 63 },
+    ]);
+    const res = await resolveCauseNumber('910/3134/22', db);
+
+    // Do not "upgrade" someone who was already specific, even to a bigger case.
+    expect(res.resolved).toBe('910/3134/22');
+    expect(res.ambiguous).toBe(false);
+  });
+
+  it('refuses to choose when one base number covers several real cases', async () => {
+    const db = makeDb([
+      { cause_num: '123/456/20-ц', member_count: 12 },
+      { cause_num: '123/456/20-а', member_count: 9 },
+    ]);
+    const res = await resolveCauseNumber('123/456/20', db);
+
+    // ~1 base in 700 carries two suffixes and those are different cases. Merging them
+    // would fabricate a single instance chain out of two, so the caller is told instead.
+    expect(res.resolved).toBeNull();
+    expect(res.ambiguous).toBe(true);
+    expect(res.matches.map((m) => m.cause_num)).toEqual(['123/456/20-ц', '123/456/20-а']);
+  });
+
+  it('resolves to nothing when the number matches no case at all', async () => {
+    const res = await resolveCauseNumber('999/999/99', makeDb([]));
+
+    expect(res.resolved).toBeNull();
+    expect(res.ambiguous).toBe(false);
+    expect(res.matches).toEqual([]);
+  });
+
+  it('falls back silently when the lookup fails or no pool is available', async () => {
+    const broken = { query: jest.fn(() => Promise.reject(new Error('boom'))) };
+    await expect(resolveCauseNumber('369/6892/15', broken)).resolves.toEqual({
+      resolved: null, matches: [], ambiguous: false,
+    });
+    // No pool at all (optional constructor arg not wired) must not throw either.
+    await expect(resolveCauseNumber('369/6892/15', undefined)).resolves.toEqual({
+      resolved: null, matches: [], ambiguous: false,
+    });
+  });
+
+  it('does not query for an empty case number', async () => {
+    const db = makeDb([{ cause_num: 'x', member_count: 1 }]);
+    const res = await resolveCauseNumber('   ', db);
+
+    expect(db.query).not.toHaveBeenCalled();
+    expect(res.resolved).toBeNull();
+  });
+});

--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -30,6 +30,7 @@ import { LegislationTools } from './legislation-tools.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from './base-tool-handler.js';
 import { extractSourceStrings, generateCaseNumberVariations, resolveCauseNumber } from './tool-utils.js';
 import type { CitationGraphService } from '../services/citation-graph-service.js';
+import type { EdsrFtsService } from '../services/edrsr-fts-service.js';
 
 export type StreamEventCallback = (event: {
   type: string;
@@ -54,6 +55,26 @@ export class MCPQueryAPI extends BaseToolHandler {
     private db?: any
   ) {
     super();
+  }
+
+  /**
+   * EDRSR corpus pool, injected after construction because EdsrFtsService is built in the
+   * tool-services factory, one layer above this one.
+   */
+  private ftsService?: EdsrFtsService;
+
+  setEdsrFtsService(ftsService: EdsrFtsService): void {
+    this.ftsService = ftsService;
+  }
+
+  /**
+   * Pool holding edrsr_case_index. When EDRSR_DATABASE_URL is set the corpus lives in its
+   * own database, and looking a cause_num up in the main pool finds no such table — the
+   * resolver would fail closed and quietly stop rewriting case numbers in exactly the
+   * deployments that read EDRSR remotely. Mirrors CourtDecisionTools.edrsrDb().
+   */
+  private edrsrDb(): any {
+    return this.ftsService?.getDedicatedPool() ?? this.db;
   }
 
   private async classifyIntentTool(args: any) {
@@ -246,7 +267,7 @@ export class MCPQueryAPI extends BaseToolHandler {
     let effectiveCaseNumber = caseNumber;
     let resolution: Awaited<ReturnType<typeof resolveCauseNumber>> | undefined;
     if (caseNumber) {
-      resolution = await resolveCauseNumber(caseNumber, this.db);
+      resolution = await resolveCauseNumber(caseNumber, this.edrsrDb());
       if (resolution.resolved) effectiveCaseNumber = resolution.resolved;
     }
 

--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -28,7 +28,7 @@ import { HallucinationGuard } from '../services/hallucination-guard.js';
 import { logger } from '../utils/logger.js';
 import { LegislationTools } from './legislation-tools.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from './base-tool-handler.js';
-import { extractSourceStrings, generateCaseNumberVariations, resolveCauseNumber } from './tool-utils.js';
+import { extractSourceStrings, generateCaseNumberVariations, resolveCauseNumber, edrsrPool } from './tool-utils.js';
 import type { CitationGraphService } from '../services/citation-graph-service.js';
 import type { EdsrFtsService } from '../services/edrsr-fts-service.js';
 
@@ -68,13 +68,12 @@ export class MCPQueryAPI extends BaseToolHandler {
   }
 
   /**
-   * Pool holding edrsr_case_index. When EDRSR_DATABASE_URL is set the corpus lives in its
-   * own database, and looking a cause_num up in the main pool finds no such table — the
-   * resolver would fail closed and quietly stop rewriting case numbers in exactly the
-   * deployments that read EDRSR remotely. Mirrors CourtDecisionTools.edrsrDb().
+   * Pool holding edrsr_case_index — see edrsrPool. Looking a cause_num up in the main pool
+   * when the corpus is remote finds no such table, so the resolver would fail closed and
+   * quietly stop rewriting case numbers in exactly those deployments.
    */
   private edrsrDb(): any {
-    return this.ftsService?.getDedicatedPool() ?? this.db;
+    return edrsrPool(this.ftsService, this.db);
   }
 
   private async classifyIntentTool(args: any) {

--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -28,7 +28,7 @@ import { HallucinationGuard } from '../services/hallucination-guard.js';
 import { logger } from '../utils/logger.js';
 import { LegislationTools } from './legislation-tools.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from './base-tool-handler.js';
-import { extractSourceStrings, generateCaseNumberVariations } from './tool-utils.js';
+import { extractSourceStrings, generateCaseNumberVariations, resolveCauseNumber } from './tool-utils.js';
 import type { CitationGraphService } from '../services/citation-graph-service.js';
 
 export type StreamEventCallback = (event: {
@@ -47,7 +47,11 @@ export class MCPQueryAPI extends BaseToolHandler {
     private citationValidator: CitationValidator,
     private hallucinationGuard: HallucinationGuard,
     private legislationTools: LegislationTools,
-    private citationGraphService?: CitationGraphService
+    private citationGraphService?: CitationGraphService,
+    // Used only to resolve a case number to the spelling EDRSR actually stores
+    // (see resolveCauseNumber). Optional so existing call sites keep working; without it
+    // the number is passed through exactly as supplied, which is the old behaviour.
+    private db?: any
   ) {
     super();
   }
@@ -233,7 +237,23 @@ export class MCPQueryAPI extends BaseToolHandler {
     // A ЄДРСР doc_id is all-digits; case numbers contain slashes (e.g. 922/989/18).
     const docId = args.doc_id || (/^\d+$/.test(String(caseId)) ? String(caseId) : '');
 
-    const status = await this.citationValidator.validatePrecedentStatus(caseId, caseNumber || undefined);
+    // Resolve the case number to the spelling EDRSR stores before anything queries with it.
+    // The chat model drops the procedural suffix on the way in — it asked about
+    // 369/6892/15-ц and called this tool with 369/6892/15 — and the bare number matches
+    // nothing, so shepardization came back `unknown` (0.5) instead of explicitly_overruled
+    // (0.95) and the answer read "справу не знайдено в ЄДРСР". A wrong-but-confident
+    // negative on the one question this tool exists to answer.
+    let effectiveCaseNumber = caseNumber;
+    let resolution: Awaited<ReturnType<typeof resolveCauseNumber>> | undefined;
+    if (caseNumber) {
+      resolution = await resolveCauseNumber(caseNumber, this.db);
+      if (resolution.resolved) effectiveCaseNumber = resolution.resolved;
+    }
+
+    const status = await this.citationValidator.validatePrecedentStatus(
+      caseId,
+      effectiveCaseNumber || undefined,
+    );
 
     // Best-effort precedent-weight signal from the decision↔case graph (Neo4j,
     // LEXAI-1777): how many decisions cite this case. Gated by CITATION_BACKEND=neo4j;
@@ -241,7 +261,9 @@ export class MCPQueryAPI extends BaseToolHandler {
     let citationGraph: any = undefined;
     if (this.citationGraphService?.isEnabled() && caseNumber) {
       try {
-        const variations = generateCaseNumberVariations(caseNumber);
+        // Resolved spelling, so the graph lookup and the shepardization above agree on
+        // which case they are talking about.
+        const variations = generateCaseNumberVariations(effectiveCaseNumber);
         const stat = await this.citationGraphService.getCaseStats(variations);
         if (stat && (stat.citingDecisions > 0 || stat.departedByDecision)) {
           citationGraph = {
@@ -336,7 +358,25 @@ export class MCPQueryAPI extends BaseToolHandler {
         {
           type: 'text',
           text: JSON.stringify(
-            { status: effectiveStatus, ...(citationGraph ? { citation_graph: citationGraph } : {}) },
+            {
+              status: effectiveStatus,
+              // Surface the rewrite so a caller reading the answer can see which case was
+              // actually checked, and so an ambiguous base number is never answered by a
+              // guess — the client is told which spellings exist and asked to pick.
+              ...(resolution?.resolved && resolution.resolved !== caseNumber
+                ? { resolved_case_number: resolution.resolved, requested_case_number: caseNumber }
+                : {}),
+              ...(resolution?.ambiguous
+                ? {
+                    ambiguous_case_number: {
+                      requested: caseNumber,
+                      candidates: resolution.matches.map((m) => m.cause_num),
+                      note: 'Номер справи без суфікса відповідає кільком різним справам. Уточніть номер повністю (наприклад, з -ц або -а) — статус нижче стосується саме введеного номера і може бути неповним.',
+                    },
+                  }
+                : {}),
+              ...(citationGraph ? { citation_graph: citationGraph } : {}),
+            },
             null,
             2
           ),

--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -187,6 +187,15 @@ const CAUSE_NUM_SUFFIXES = [
 const HAS_SUFFIX_RE = /-[а-яіїєґА-ЯІЇЄҐ]+$/;
 
 /**
+ * A trailing "-token" the caller typed, where the token carries at least one letter in any
+ * alphabet. Broader than HAS_SUFFIX_RE on purpose: candidate generation only ever produces
+ * Cyrillic suffixes, but the guard against swapping one has to recognise a suffix we would
+ * never generate — a Latin or otherwise unmeasured tail is still the caller saying which
+ * case they mean. The letter requirement keeps numeric tails like "5-15" out of it.
+ */
+const ASKED_SUFFIX_RE = /-[^/\s-]*[A-Za-zА-Яа-яІіЇїЄєҐґ][^/\s-]*$/;
+
+/**
  * Case-number spellings worth probing against the corpus — the variations above, plus a
  * suffixed form of every unsuffixed one.
  *
@@ -210,6 +219,18 @@ export function generateCaseNumberCandidates(caseNumber: string): string[] {
     }
   }
   return Array.from(candidates);
+}
+
+/**
+ * Pool holding the EDRSR corpus tables (edrsr_documents / edrsr_fulltext / edrsr_case_index).
+ *
+ * When EDRSR_DATABASE_URL is set the corpus lives in its own database and EdsrFtsService
+ * opens a dedicated pool for it; otherwise it is co-located with the application data and
+ * the caller's own pool is right. Shared rather than copied per tool class, so the rule has
+ * one home and cannot drift between the tools that read the corpus.
+ */
+export function edrsrPool(ftsService: { getDedicatedPool(): any } | undefined, fallback: any): any {
+  return ftsService?.getDedicatedPool() ?? fallback;
 }
 
 export interface CauseNumberResolution {
@@ -250,7 +271,19 @@ export async function resolveCauseNumber(caseNumber: string, dbPool: any): Promi
         ORDER BY member_count DESC NULLS LAST`,
       [generateCaseNumberCandidates(input)],
     );
-    const matches = rows.map((r: any) => ({ cause_num: r.cause_num as string, member_count: Number(r.member_count) }));
+    const all = rows.map((r: any) => ({ cause_num: r.cause_num as string, member_count: Number(r.member_count) }));
+
+    // A suffix the caller typed is a statement about WHICH case they mean, so it may be
+    // completed but never swapped. Without this, "905/1234/20-XYZ" (a suffix outside the
+    // measured set, hence not in the corpus) would strip down to "905/1234/20", pick up the
+    // measured suffixes as candidates, and resolve to 905/1234/20-ц — a different real case
+    // answered as if it were the one asked about. Year expansion still works, because an
+    // expanded variant keeps the same suffix.
+    const askedSuffix = input.match(ASKED_SUFFIX_RE)?.[0] ?? null;
+    const matches = askedSuffix
+      ? all.filter((m: { cause_num: string }) => (m.cause_num.match(ASKED_SUFFIX_RE)?.[0] ?? null) === askedSuffix)
+      : all;
+
     if (matches.length === 0) return empty;
     if (matches.some((m: { cause_num: string }) => m.cause_num === input)) {
       return { resolved: input, matches, ambiguous: false };

--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -167,6 +167,106 @@ export function extractSnippets(fullText: string, query: string, limit: number):
 }
 
 /**
+ * Suffixes that actually occur in EDRSR `cause_num`, taken from a 3% sample of
+ * edrsr_case_index rather than guessed. The four procedural ones carry 99.9% of the
+ * volume — ц 112,049 / к 64,556 / п 61,022 / а 17,155 — and the rest is a long thin tail
+ * (С 748, г 561, Е 360, А 334, Ц 65, НМ 51, Б 45, ад 42, К 20, НА 20, б 17, АП 16, Д 10,
+ * НР 6, Н 3, н 3) that mostly belongs to older commercial and bankruptcy numbering.
+ *
+ * The tail is included because each entry costs one extra equality probe on a primary-key
+ * index and nothing else. Anything outside the set simply fails to resolve, and the caller
+ * keeps whatever it did before — this is a lookup shortcut, not a validation rule.
+ */
+const CAUSE_NUM_SUFFIXES = [
+  'ц', 'к', 'п', 'а',
+  'Ц', 'К', 'П', 'А',
+  'С', 'с', 'г', 'Г', 'е', 'Е', 'Б', 'б', 'Д', 'д', 'Н', 'н',
+  'НМ', 'НА', 'НР', 'АП', 'ад',
+];
+
+const HAS_SUFFIX_RE = /-[а-яіїєґА-ЯІЇЄҐ]+$/;
+
+/**
+ * Case-number spellings worth probing against the corpus — the variations above, plus a
+ * suffixed form of every unsuffixed one.
+ *
+ * generateCaseNumberVariations is deliberately asymmetric: it STRIPS a suffix but never
+ * adds one, so "369/6892/15-ц" degrades to "369/6892/15" while the reverse never happens.
+ * That is the direction that breaks in practice, because the chat model drops the suffix
+ * on its way to the tool and the bare number matches nothing.
+ *
+ * These are candidates, not answers. Roughly 1 base number in 700 carries two different
+ * suffixes (364 of 263,565 distinct bases in the same sample), and those are genuinely
+ * different cases — which is why resolveCauseNumber looks them up rather than passing the
+ * whole list to a `cause_num = ANY(...)` filter, where two unrelated cases would silently
+ * merge into one instance chain.
+ */
+export function generateCaseNumberCandidates(caseNumber: string): string[] {
+  const candidates = new Set<string>();
+  for (const variant of generateCaseNumberVariations(caseNumber)) {
+    candidates.add(variant);
+    if (!HAS_SUFFIX_RE.test(variant)) {
+      for (const suffix of CAUSE_NUM_SUFFIXES) candidates.add(`${variant}-${suffix}`);
+    }
+  }
+  return Array.from(candidates);
+}
+
+export interface CauseNumberResolution {
+  /** The spelling to query with, or null when nothing matched or the input is ambiguous. */
+  resolved: string | null;
+  /** Every candidate that exists in the corpus, most documents first. */
+  matches: Array<{ cause_num: string; member_count: number }>;
+  /** True when several distinct cases share the base number — the caller must not guess. */
+  ambiguous: boolean;
+}
+
+/**
+ * Resolve a user- or model-supplied case number to the spelling EDRSR actually uses.
+ *
+ * Looks the candidates up by equality against `edrsr_case_index` (cause_num is its primary
+ * key, so this is a handful of btree probes — 1.7ms measured on prod for 12 candidates).
+ * Equality rather than `LIKE 'base%'` on purpose: the database collation is en_US.utf8, so
+ * a prefix LIKE cannot use that index and seq-scans instead (5.2s measured), and a
+ * collation-ordered range would depend on how glibc sorts punctuation.
+ *
+ * An exact hit on the caller's own spelling always wins — they may have been specific.
+ * Otherwise a single surviving candidate is the answer. Several means the base number maps
+ * to more than one real case, and the resolution stays null so nothing is silently merged.
+ *
+ * Fail-safe: any error (or no pool) resolves to null with no matches, leaving the caller on
+ * whatever it did before.
+ */
+export async function resolveCauseNumber(caseNumber: string, dbPool: any): Promise<CauseNumberResolution> {
+  const empty: CauseNumberResolution = { resolved: null, matches: [], ambiguous: false };
+  const input = String(caseNumber || '').trim();
+  if (!input || !dbPool?.query) return empty;
+
+  try {
+    const { rows } = await dbPool.query(
+      `SELECT cause_num, COALESCE(member_count, 0)::int AS member_count
+         FROM edrsr_case_index
+        WHERE cause_num = ANY($1::text[])
+        ORDER BY member_count DESC NULLS LAST`,
+      [generateCaseNumberCandidates(input)],
+    );
+    const matches = rows.map((r: any) => ({ cause_num: r.cause_num as string, member_count: Number(r.member_count) }));
+    if (matches.length === 0) return empty;
+    if (matches.some((m: { cause_num: string }) => m.cause_num === input)) {
+      return { resolved: input, matches, ambiguous: false };
+    }
+    if (matches.length === 1) return { resolved: matches[0].cause_num, matches, ambiguous: false };
+    return { resolved: null, matches, ambiguous: true };
+  } catch (error: any) {
+    logger.warn('[tool-utils] resolveCauseNumber failed; keeping the caller-supplied number', {
+      caseNumber: input,
+      error: error?.message,
+    });
+    return empty;
+  }
+}
+
+/**
  * Generate case number variations (short/long year, with/without suffix).
  */
 export function generateCaseNumberVariations(caseNumber: string): string[] {

--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -273,8 +273,11 @@ export function generateCaseNumberVariations(caseNumber: string): string[] {
   const variations = new Set<string>();
   variations.add(caseNumber);
 
-  // Standard format: 123/456/22-ц
-  const match = caseNumber.match(/^(\d+\/\d+\/)(\d{2,4})(-[а-яіїєґА-ЯІЇЄҐ])?$/);
+  // Standard format: 123/456/22-ц. The suffix group is `+`, not a single character: the
+  // corpus carries multi-letter ones too (ад, НМ, НА, НР, АП — see CAUSE_NUM_SUFFIXES), and
+  // with a single-character group the whole regex missed them, so those numbers got no
+  // year expansion at all.
+  const match = caseNumber.match(/^(\d+\/\d+\/)(\d{2,4})(-[а-яіїєґА-ЯІЇЄҐ]+)?$/);
   if (match) {
     const prefix = match[1];
     const year = match[2];

--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -187,13 +187,21 @@ const CAUSE_NUM_SUFFIXES = [
 const HAS_SUFFIX_RE = /-[а-яіїєґА-ЯІЇЄҐ]+$/;
 
 /**
- * A trailing "-token" the caller typed, where the token carries at least one letter in any
- * alphabet. Broader than HAS_SUFFIX_RE on purpose: candidate generation only ever produces
+ * A procedural suffix the caller typed, captured in group 1.
+ *
+ * Broader than HAS_SUFFIX_RE in one direction: candidate generation only ever produces
  * Cyrillic suffixes, but the guard against swapping one has to recognise a suffix we would
  * never generate — a Latin or otherwise unmeasured tail is still the caller saying which
- * case they mean. The letter requirement keeps numeric tails like "5-15" out of it.
+ * case they mean.
+ *
+ * Anchored to the modern digits/digits/year shape in the other direction, because a bare
+ * trailing "-token" is not always a suffix. Pre-2017 Supreme Court numbers put a hyphen in
+ * the middle of the identifier itself: "5-15кс12" would otherwise read as suffix "-15кс12"
+ * and then fail to match its own canonical spelling "5-15/12", which carries no suffix at
+ * all — so the guard would have blocked exactly the rewrite the VSU branch of
+ * generateCaseNumberVariations exists to perform.
  */
-const ASKED_SUFFIX_RE = /-[^/\s-]*[A-Za-zА-Яа-яІіЇїЄєҐґ][^/\s-]*$/;
+const ASKED_SUFFIX_RE = /^\d+\/\d+\/\d{2,4}(-[^/\s-]*[A-Za-zА-Яа-яІіЇїЄєҐґ][^/\s-]*)$/;
 
 /**
  * Case-number spellings worth probing against the corpus — the variations above, plus a
@@ -279,9 +287,9 @@ export async function resolveCauseNumber(caseNumber: string, dbPool: any): Promi
     // measured suffixes as candidates, and resolve to 905/1234/20-ц — a different real case
     // answered as if it were the one asked about. Year expansion still works, because an
     // expanded variant keeps the same suffix.
-    const askedSuffix = input.match(ASKED_SUFFIX_RE)?.[0] ?? null;
+    const askedSuffix = input.match(ASKED_SUFFIX_RE)?.[1] ?? null;
     const matches = askedSuffix
-      ? all.filter((m: { cause_num: string }) => (m.cause_num.match(ASKED_SUFFIX_RE)?.[0] ?? null) === askedSuffix)
+      ? all.filter((m: { cause_num: string }) => (m.cause_num.match(ASKED_SUFFIX_RE)?.[1] ?? null) === askedSuffix)
       : all;
 
     if (matches.length === 0) return empty;

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -22,7 +22,7 @@ import type { CitationGraphService } from '../../services/citation-graph-service
 import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
-import { generateCaseNumberVariations, extractSnippets, resolveCauseNumber } from '../tool-utils.js';
+import { generateCaseNumberVariations, extractSnippets, resolveCauseNumber, edrsrPool } from '../tool-utils.js';
 
 export class CourtDecisionTools extends BaseToolHandler {
   constructor(
@@ -46,7 +46,7 @@ export class CourtDecisionTools extends BaseToolHandler {
    * to this.db — byte-identical to the previous behaviour.
    */
   private edrsrDb(): any {
-    return this.ftsService?.getDedicatedPool() ?? this.db;
+    return edrsrPool(this.ftsService, this.db);
   }
 
   /** True when reads are routed to the dedicated EDRSR pool (stage). */

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -756,8 +756,10 @@ total_resolved_links=0 означає відсутність даних граф
 
     const payload: any = {
       case_number: effectiveCaseNumber,
+      // Same rewrite metadata check_precedent_status emits, spelled the same way, so a
+      // client can detect a resolved suffix uniformly across both tools.
       ...(resolution.resolved && resolution.resolved !== caseNumber
-        ? { requested_case_number: caseNumber }
+        ? { resolved_case_number: resolution.resolved, requested_case_number: caseNumber }
         : {}),
       total_documents: mappedDocs.length,
       documents: groupByInstance ? undefined : mappedDocs,

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -22,7 +22,7 @@ import type { CitationGraphService } from '../../services/citation-graph-service
 import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
-import { generateCaseNumberVariations, extractSnippets } from '../tool-utils.js';
+import { generateCaseNumberVariations, extractSnippets, resolveCauseNumber } from '../tool-utils.js';
 
 export class CourtDecisionTools extends BaseToolHandler {
   constructor(
@@ -590,8 +590,22 @@ total_resolved_links=0 означає відсутність даних граф
       groupByInstance
     });
 
-    const caseVariations = generateCaseNumberVariations(caseNumber);
-    logger.info('Generated case number variations', { variations: caseVariations });
+    // Resolve the procedural suffix first. The chat model strips it on the way in (asked
+    // about 369/6892/15-ц, called with 369/6892/15), and the bare number matches no
+    // cause_num at all, so the chain came back empty and the answer said the case does not
+    // exist. resolveCauseNumber only rewrites when exactly one real case fits; an ambiguous
+    // base is left alone rather than merged, since ~1 base in 700 covers two distinct cases.
+    const resolution = await resolveCauseNumber(caseNumber, this.edrsrDb());
+    const effectiveCaseNumber = resolution.resolved || caseNumber;
+
+    const caseVariations = generateCaseNumberVariations(effectiveCaseNumber);
+    logger.info('Generated case number variations', {
+      variations: caseVariations,
+      ...(resolution.resolved && resolution.resolved !== caseNumber
+        ? { requested: caseNumber, resolved: resolution.resolved }
+        : {}),
+      ...(resolution.ambiguous ? { ambiguous: resolution.matches.map(m => m.cause_num) } : {}),
+    });
 
     // Query edrsr_documents directly with all case number variations
     const fulltextJoin = includeFullText
@@ -656,7 +670,17 @@ total_resolved_links=0 означає відсутність даних граф
         total_documents: 0,
         documents: [],
         search_stats: { variations_tried: caseVariations },
-        message: `Документів не знайдено за номером справи: ${caseNumber} (перевірено варіації: ${caseVariations.join(', ')})`,
+        ...(resolution.ambiguous
+          ? {
+              ambiguous_case_number: {
+                requested: caseNumber,
+                candidates: resolution.matches.map(m => m.cause_num),
+              },
+            }
+          : {}),
+        message: resolution.ambiguous
+          ? `Номер справи ${caseNumber} без суфікса відповідає кільком різним справам (${resolution.matches.map(m => m.cause_num).join(', ')}). Уточніть номер повністю.`
+          : `Документів не знайдено за номером справи: ${caseNumber} (перевірено варіації: ${caseVariations.join(', ')})`,
       });
     }
 
@@ -731,7 +755,10 @@ total_resolved_links=0 означає відсутність даних граф
     }
 
     const payload: any = {
-      case_number: caseNumber,
+      case_number: effectiveCaseNumber,
+      ...(resolution.resolved && resolution.resolved !== caseNumber
+        ? { requested_case_number: caseNumber }
+        : {}),
       total_documents: mappedDocs.length,
       documents: groupByInstance ? undefined : mappedDocs,
       grouped_documents: groupByInstance ? groupedDocs : undefined,

--- a/mcp_backend/src/factories/__tests__/tool-services.test.ts
+++ b/mcp_backend/src/factories/__tests__/tool-services.test.ts
@@ -223,7 +223,7 @@ function makeCoreServices() {
     },
     reyestrDownloadService: { download: jest.fn() },
     importTaskService: { create: jest.fn() },
-    mcpAPI: { getTools: jest.fn().mockReturnValue([]) },
+    mcpAPI: { getTools: jest.fn().mockReturnValue([]), setEdsrFtsService: jest.fn() },
   } as any;
 }
 

--- a/mcp_backend/src/factories/core-services.ts
+++ b/mcp_backend/src/factories/core-services.ts
@@ -73,7 +73,8 @@ export function createBackendCoreServices(): BackendCoreServices {
     citationValidator,
     hallucinationGuard,
     legislationTools,
-    citationGraphService
+    citationGraphService,
+    db
   );
 
   return {

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -96,6 +96,10 @@ export function createToolServices(
 
   // EDRSR FTS service — instantiated early so procedural/unified tools can share it
   const edsrFtsService = new EdsrFtsService();
+  // check_precedent_status resolves case numbers against edrsr_case_index, which lives in
+  // the dedicated EDRSR database when EDRSR_DATABASE_URL is set. Hand the service over so
+  // it reads the corpus from the same pool the corpus tools use.
+  coreServices.mcpAPI.setEdsrFtsService(edsrFtsService);
 
   // Register all tool handlers with the central registry
   toolRegistry.registerHandler(coreServices.legislationTools);


### PR DESCRIPTION
## Why

Asked whether the Grand Chamber departed from the position in **369/6892/15-ц**, the chat called `check_precedent_status` with **369/6892/15** — it strips the procedural suffix on the way to the tool. The bare number matches no `cause_num`, so:

| input | result |
|---|---|
| `369/6892/15-ц` | `explicitly_overruled`, overruled_by ВП ВС 75296530 + 85676704, confidence 0.95 |
| `369/6892/15` | `unknown`, confidence 0.5 |

Six tool calls, 63 seconds, and the answer read *«Справа 369/6892/15-ц **не знайдена в ЄДРСР** жодним із доступних методів»* — a confident false negative on the one question the tool exists to answer. `get_case_documents_chain` returned an empty chain for the same reason.

External MCP v2 clients reach the same handler, so both surfaces were affected. Fixing it in the tool rather than the chat prompt covers both at once: `check_precedent_status` is in `FIXED_V2_TOOLS` **and** `V2_TOOL_NAMES`.

## Equality, not prefix LIKE

`resolveCauseNumber` probes candidate spellings against `edrsr_case_index`, whose primary key is `cause_num`.

| form | time |
|---|---|
| `cause_num LIKE 'base%'` | 5.2s (collation is en_US.utf8 — prefix LIKE cannot use the index, seq-scans) |
| `cause_num = ANY(...)`, 12 candidates | **1.7ms** |
| `cause_num = ANY(...)`, full 52 candidates | **2.2ms** |

A collation-ordered range worked in testing (3.2ms) but depends on how glibc sorts punctuation, so equality it is.

## It resolves — it does not enumerate

The candidate list could just be handed to the existing `cause_num = ANY(...)` filters. It is not, because roughly **1 base number in 700 carries two different suffixes** (364 of 263,565 distinct bases in a 3% sample) and those are *different cases* — `1/158` exists alongside `1/158-Б`, `1/158-Д` and `1/158-НМ`. Merging them would fabricate one instance chain out of several.

So: an exact hit on the caller's own spelling always wins; a single surviving candidate is the answer; several leaves the resolution `null` and reports the alternatives instead of guessing.

## The suffix list is measured

From a 3% sample of `edrsr_case_index`: **ц 112,049 / к 64,556 / п 61,022 / а 17,155** carry 99.9% of the volume. The tail (`С` 748, `г` 561, `Е` 360, `А` 334, `Ц` 65, `НМ` 51, `Б` 45, `ад` 42, `К` 20, `НА` 20, `б` 17, `АП` 16, `Д` 10, `НР` 6, `Н` 3, `н` 3) is included because each entry costs one more primary-key probe. Anything outside the set fails to resolve and the caller keeps its old behaviour.

## Verified against prod data

- `369/6892/15` → `369/6892/15-ц`, 1.98ms
- `925/1133/18` → exact match, 0.33ms
- `1/158` → keeps the caller's spelling, because it is itself a real case

Both responses now carry `resolved_case_number` when a rewrite happened, and an ambiguous base is reported with its candidates rather than answered.

## Tests

8 new tests covering: suffix candidates generated (and not stacked onto an already-suffixed number), rewrite of a stripped number, caller spelling preferred over a larger sibling, refusal to choose among several real cases, no match, DB failure and missing pool falling back silently, empty input not querying. `tsc` clean. The two pre-existing failures in `search-legal-precedents` / `get-legal-advice-cpc-gpc` are unchanged from `main` (verified by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false negatives when a case number arrives without its procedural suffix by resolving it to the exact `cause_num` before any queries; also handles legacy VSU hyphen numbers so they canonicalize correctly. Applies to `check_precedent_status` and `get_case_documents_chain`, works with a dedicated EDRSR DB, and surfaces the resolved number in responses.

- **Bug Fixes**
  - Added `resolveCauseNumber` to probe candidates via `cause_num = ANY($1)` on `edrsr_case_index` (1–2 ms vs 5.2 s for prefix `LIKE`).
  - Never swaps a caller‑typed suffix: matches are filtered to the same suffix (any trailing “-token” with a letter), with year expansion allowed within that suffix; multi‑letter suffixes are supported via a `+` regex; legacy VSU hyphens are not treated as suffixes (e.g., `5-15кс12` → `5-15/12`).
  - Candidate generation uses a measured suffix set; exact caller spelling wins; multiple real matches are flagged as ambiguous (no guessing); no suffix stacking.
  - Pool selection shared via `edrsrPool`; `MCPQueryAPI` receives `EdsrFtsService` through `setEdsrFtsService`, so resolution works with `EDRSR_DATABASE_URL` and falls back to the app pool.
  - Both shepardization and the citation graph use the same resolved number; tool responses include `resolved_case_number` and `requested_case_number`, and `ambiguous_case_number` with candidates when needed.
  - Added tests for VSU handling, non‑swap guard, ambiguity, multi‑letter suffix handling, fallbacks, and empty inputs.

<sup>Written for commit c33120ed7e47d571ae2e3f5381a7d21a398eb9c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

