### PR TITLE
feat(mcp): expose the full Ukrainian open-data surface on MCP v2

### DIFF
--- a/mcp_backend/src/api/curated-mcp-tools.ts
+++ b/mcp_backend/src/api/curated-mcp-tools.ts
@@ -11,9 +11,13 @@
  *   • /sse         (legacy SSE transport, MCPSSEServer)
  *
  * IMPORTANT: keep this in sync with the actual handler names registered in
- * factories/tool-services.ts. Every name here must resolve to a LOCAL handler so
- * it appears in ToolRegistry.getLocalToolDefinitions() (the SSE transport only
- * lists local tools).
+ * factories/tool-services.ts (local tools) and with the remote routes in
+ * tool-registry.ts (rada_* / openreyestr_*).
+ *
+ * Local vs remote matters per transport: /api/v2/mcp merges remote definitions via
+ * getAllToolDefinitions(), so prefixed tools resolve there. /sse lists only
+ * getLocalToolDefinitions(), so every prefixed (rada_, openreyestr_) name below is
+ * skipped on that transport and logged as missing — expected, not a regression.
  */
 export const V2_TOOL_NAMES = new Set<string>([
   // Legislation (6)
@@ -49,4 +53,35 @@ export const V2_TOOL_NAMES = new Set<string>([
   'openreyestr_search_arma_seized_assets',
   'openreyestr_search_nazk_declarations',
   'openreyestr_search_notaries',
+  // ЄДР — решта OpenReyestr: податковий борг, ЄСВ, єдиний податок, припинення,
+  // арбітражні керуючі, спеціальні форми, зведена статистика реєстрів.
+  'openreyestr_search_tax_debt',
+  'openreyestr_search_esv_debt',
+  'openreyestr_search_single_tax_payers',
+  'openreyestr_search_termination_started',
+  'openreyestr_search_arbitration_managers',
+  'openreyestr_search_special_forms',
+  'openreyestr_get_statistics',
+  // Парламент — remote (rada_*). Законопроєкти, супровідні документи (висновки
+  // ГНЕУ/комітетів/ГЮУ), депутати, голосування.
+  // rada_search_legislation_text свідомо НЕ включено: rada.legislation — поверхневий
+  // кеш карток, його full_text_plain містить навігаційний мотлох, а не текст акта.
+  'rada_search_parliament_bills',
+  'rada_search_bill_documents',
+  'rada_get_deputy_info',
+  'rada_analyze_voting_record',
+  // Відкриті дані України — local handlers.
+  'search_public_spending',        // Є-Data: spending_acts 8.8M, addendums 2M
+  'search_edrnpa',                 // ЄДРНПА Мін'юсту: 141K карток + тексти
+  'search_court_case_status',      // стан розгляду справ (лише Верховний Суд, 1.25M)
+  'search_court_hearing_schedule', // розклад засідань, 481K
+  'search_invalid_passports',      // недійсні паспорти, 2.89M + 195K закордонних
+  'search_judges',                 // судді: judges_current + історія
+  'search_vrp_judges_discipline',  // ВРП: звільнені / відсторонені / втручання
+  'search_vkks',                   // ВККС: судді, оцінювання, декларації, вакансії
+  // Інтелектуальна власність — ip_objects 820K + ip_object_events 2.0M.
+  'search_ip_objects',
+  'get_ip_object',
+  'get_trademark_dossier',
+  'find_similar_trademarks',
 ]);


### PR DESCRIPTION
## Навіщо

Демо EVERLEGAL 13.08. У листі обіцяно «ключові державні реєстри» та «аналітичний рівень з MCP-конекторами», але зовнішній MCP їх майже не віддає.

Перевірено на проді 12.08: `/api/v2/mcp` віддає **28 інструментів**, тоді як `ToolRegistry` реєструє **121**. Близько двадцяти робочих інструментів по українських даних просто не внесені у whitelist, а всі п'ять `rada_*` відсутні — парламентські дані недоступні зовнішньому клієнту взагалі.

Це не нові можливості. Це відкриття того, що вже задеплоєне й працює.

## Що додано (23 назви, 28 → 51)

| Домен | Інструменти | Дані на проді |
|---|---|---|
| Парламент | `rada_search_parliament_bills`, `rada_search_bill_documents`, `rada_get_deputy_info`, `rada_analyze_voting_record` | 15K законопроєктів, 241K супровідних документів |
| ЄДР (решта) | `openreyestr_search_tax_debt`, `_esv_debt`, `_single_tax_payers`, `_termination_started`, `_arbitration_managers`, `_special_forms`, `openreyestr_get_statistics` | податковий борг 861K, ЄСВ 668K, спецформи 4.7M |
| Відкриті дані | `search_public_spending`, `search_edrnpa`, `search_court_case_status`, `search_court_hearing_schedule`, `search_invalid_passports`, `search_judges`, `search_vrp_judges_discipline`, `search_vkks` | Є-Data 8.8M актів, ЄДРНПА 141K, паспорти 2.89M |
| Інтелектуальна власність | `search_ip_objects`, `get_ip_object`, `get_trademark_dossier`, `find_similar_trademarks` | `ip_objects` 820K + 2.0M подій |

**Свідомо не додано:** `rada_search_legislation_text` (таблиця `rada.legislation` — поверхневий кеш карток, `full_text_plain` містить навігаційний мотлох); `search_echr_practice`, `get_echr_document`, `search_legal_acts`, `get_legal_act_meta` (усі через вимкнений ZakonOnline-адаптер, повертають порожньо); `search_terrorism_list` (3 рядки).

## Перевірка

- **Усі 23 назви резолвяться у живому реєстрі прода: 23/23, `MISSING: []`.** Це найважливіша перевірка — назва з одруківкою мовчки випала б у `missingTools`.
- `npx tsc --noEmit` — по цьому файлу чисто. Решта помилок (`core-loader.ts`, `registry-catalog.ts` MatchType) наявні на `main` і цим PR не зачіпаються.
- `mcp-sse-tools-whitelist.test.ts` — проходить (тест ганяє фейковий реєстр, розмір whitelist не фіксує).

Смоук кандидатів на проді через `POST /api/tools/<name>` — жоден не зламаний. Три давали порожньо з причин у даних, а не в коді, і це варто знати перед демо:

- `opendata_court_case_status` містить **лише Верховний Суд** (ККС 756K, КЦС 287K, ВП ВС 30K) — запит по суду першої інстанції коректно дає нуль;
- `search_edrnpa` матчить підрядок **без морфології** — «адвокатура» не збігається з «адвокатів» у назві акта;
- `ip_objects` пише «ЕВЕРЛІ**Ґ**АЛ» через Ґ.

Два інструменти повільні: `get_trademark_dossier` 37.7 с, `search_public_spending` 25.9 с. У межах тул-таймаутів, але на живому демо їх варто прогріти заздалегідь.

## Примітка про транспорти

`/sse` перелічує тільки локальні інструменти, тому `rada_*` і `openreyestr_*` там пропускаються і логуються як missing. Так уже було з наявними 12 `openreyestr_*` — поведінка не змінюється, лог стає гучнішим. Заголовок файлу виправлено: твердження «кожна назва має резолвитись у ЛОКАЛЬНИЙ хендлер» перестало бути правдою ще коли додали `openreyestr_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the full Ukrainian open-data surface on MCP v2 by expanding the curated tool list to include `rada_*`, remaining `openreyestr_*`, open data, and IP tools. External clients now see 51 tools (up from 28); no new handlers added, just surfacing existing routes.

- **Bug Fixes**
  - Added 23 tool names that already resolve in `ToolRegistry` (parliament bills/docs/deputies/voting, tax/ESV debt, single-tax payers, termination, arbitration managers, special forms, registry stats, public spending, EDRNPA, court status/schedule, invalid passports, judges, VRP/VKKS, IP search/dossier/similarity).
  - Verified on prod: 23/23 present; parliament and other UA datasets are now reachable via `/api/v2/mcp`.
  - Excluded `rada_search_legislation_text` due to poor source text quality.
  - Fixed header comment to note: `/api/v2/mcp` merges remote tools; `/sse` lists local only (prefixed tools are skipped by design).

<sup>Written for commit ddd8cd36f26ed54499973e61aca1144950c1b4a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

