### PR TITLE
feat(registry): add law firms, bankruptcy announcements and judge candidates

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -292,6 +292,50 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     ],
   },
 
+  law_firms: {
+    title: 'Юридичні фірми та адвокатські об’єднання',
+    description: 'Пошук юридичних фірм, адвокатських об’єднань і юридичних компаній (КВЕД 69.10 — діяльність у сфері права)\n\n10.7K записів. Пошук за назвою, ЄДРПОУ, email, сайтом.\nУВАГА: назви в реєстрі — у формі «НАЗВА, ОРГ-ФОРМА» (наприклад «ЕВЕРЛІҐАЛ, АДВОКАТСЬКЕ ОБ’ЄДНАННЯ»), тому шукати варто за коренем назви. Одна фірма може мати кілька юросіб з різними ЄДРПОУ.',
+    table: 'opendata_law_firms',
+    selectColumns: 'edrpou, name, email, phone, website, kved, source',
+    orderBy: 'name',
+    emptyMessage: 'Юридичних фірм не знайдено',
+    fields: [
+      { name: 'name', description: 'Назва фірми або адвокатського об’єднання', match: 'ilike', columns: ['name'] },
+      { name: 'edrpou', description: 'Код ЄДРПОУ', match: 'exact', columns: ['edrpou'] },
+      { name: 'email', description: 'Email', match: 'ilike', columns: ['email'] },
+      { name: 'website', description: 'Вебсайт', match: 'ilike', columns: ['website'] },
+    ],
+  },
+
+  bankruptcy_announcements: {
+    title: 'Оголошення про банкрутство та неплатоспроможність',
+    description: 'Пошук офіційних оголошень у справах про банкрутство/неплатоспроможність: відкриття провадження, санація, ліквідація, аукціони\n\n74.7K записів. Пошук за назвою або ЄДРПОУ боржника, номером справи, судом, типом оголошення.\nНЕ плутати з openreyestr_search_bankruptcy_cases — там картки справ з ЄДР, а тут стрічка публікацій. Поле case_number — це номер справи в ЄДРСР, за ним можна одразу підняти рішення через search_court_decisions.',
+    table: 'opendata_bankruptcy',
+    selectColumns: "case_num, publish_date, case_type, firm_edrpou, firm_name, case_number, court_name, start_date_auc, end_date_auc, end_registration_date",
+    orderBy: "to_date(NULLIF(publish_date, ''), 'DD.MM.YYYY') DESC NULLS LAST",
+    emptyMessage: 'Оголошень про банкрутство не знайдено',
+    fields: [
+      { name: 'firm_name', description: 'Назва боржника (юрособа або ПІБ ФОП/фізособи)', match: 'ilike', columns: ['firm_name'] },
+      { name: 'firm_edrpou', description: 'ЄДРПОУ або ІПН боржника', match: 'exact', columns: ['firm_edrpou'] },
+      { name: 'case_number', description: 'Номер судової справи (як у ЄДРСР)', match: 'exact', columns: ['case_number'] },
+      { name: 'court_name', description: 'Назва суду', match: 'ilike', columns: ['court_name'] },
+      { name: 'case_type', description: 'Тип оголошення (відкриття провадження, санація, ліквідація, аукціон)', match: 'ilike', columns: ['case_type'] },
+    ],
+  },
+
+  judge_candidates: {
+    title: 'Кандидати на посаду судді',
+    description: 'Пошук у рейтинговому списку кандидатів на посаду судді (ВККС)\n\n645 записів. Пошук за ПІБ; є місце в рейтингу, бали тестування й практичного завдання, дата затвердження та строк дії.',
+    table: 'opendata_judge_candidates',
+    selectColumns: 'rank_position, full_name, gender, test_score, practical_score, total_score, approval_date::text AS approval_date, expiry_date::text AS expiry_date',
+    orderBy: 'rank_position NULLS LAST',
+    emptyMessage: 'Кандидатів на посаду судді не знайдено',
+    fields: [
+      { name: 'full_name', description: 'ПІБ кандидата', match: 'ilike', columns: ['full_name'] },
+      { name: 'gender', description: 'Стать (Ч/Ж)', match: 'exact', columns: ['gender'] },
+    ],
+  },
+
   vrp_decisions: {
     title: 'Рішення ВРП',
     description: 'Пошук рішень Вищої ради правосуддя (ВРП)\n\n16.5K записів. Пошук за назвою, органом, номером рішення, датою.\nВключає голосування та тексти рішень.',


### PR DESCRIPTION
## Навіщо

Демо EVERLEGAL 13.08. Три українські таблиці лежать на проді без жодного способу до них дістатися. Замість трьох нових інструментів додаю їх у `REGISTRY_CATALOG` — `search_registry` уже у whitelist v2 і це той інструмент, який чат-модель стабільно обирає сама. Урок з IP-демо: правити інструмент, який модель і так викликає, а не ставити поруч новий.

| Ключ | Таблиця | Рядків |
|---|---|---|
| `law_firms` | `opendata_law_firms` | 10 766 |
| `bankruptcy_announcements` | `opendata_bankruptcy` | 74 763 |
| `judge_candidates` | `opendata_judge_candidates` | 645 |

## Перевірка

`selectColumns` і `orderBy` потрапляють у SQL, тому кожен запис прогнано **на проді**, а не лише через `tsc`:

**`law_firms`** — п'ять юросіб EVERLEGAL, зокрема адвокатське об'єднання (ЄДРПОУ **40968165**, ao@everlegal.ua) і ЕВЕРЛІҐАЛ ТОВ (**38621426**):

```
40013449 | ЕВЕРЛІГАЛ СІІІ, ТОВ
43016878 | ЕВЕРЛІГАЛ, ЮРИДИЧНА ФІРМА, ТОВ      | info@everlegal.ua
40968165 | ЕВЕРЛІҐАЛ, АДВОКАТСЬКЕ ОБ’ЄДНАННЯ   | ao@everlegal.ua
38621426 | ЕВЕРЛІҐАЛ, ТОВ
43178056 | ЕВЕРЛІҐАЛ, ЮРИДИЧНА КОМПАНІЯ, ТОВ
```

Назви зберігаються у формі «НАЗВА, ОРГ-ФОРМА», тому опис прямо каже моделі шукати за коренем назви. Написання через **Ґ** і через **Г** зустрічаються обидва.

**`bankruptcy_announcements`** — `publish_date` це текст у форматі DD.MM.YYYY, тож сортування парсить його з `NULLIF`-запобіжником. Перевірено: 72 322 з 74 763 рядків парсяться, жоден не кидає помилку (скан пройшов усю таблицю). Поле `case_number` — це номер справи в ЄДРСР, тому опис одразу вказує на `search_court_decisions` для переходу до рішень.

**`judge_candidates`** — сортування за місцем у рейтингу.

`npx tsc --noEmit` — по цьому файлу чисто (наявні на `main` помилки `core-loader.ts` і `array_contains_text` не зачіпаються).

## Свідомо не додано

`opendata_corruption_offenders` (28 833) — перетинається з наявним `corruption_register` (`opendata_corruption`, 62 637) і доменом, і колонками. Два майже однакові реєстри псують вибір моделі, а не покращують покриття.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose three Ukraine registries in `REGISTRY_CATALOG` so `search_registry` can query them: law firms, bankruptcy announcements, and judge candidates.

- **New Features**
  - `law_firms` → `opendata_law_firms` (10.7K): search by name, EDRPOU, email, website; ordered by name. Names are stored as "NAME, ORG-FORM", so search by the name root.
  - `bankruptcy_announcements` → `opendata_bankruptcy` (74.7K): search by debtor name/EDRPOU, case number, court, type; ordered by parsed `publish_date` (DD.MM.YYYY) with NULL-safe parsing. `case_number` matches ЄДРСР and can pivot to `search_court_decisions`.
  - `judge_candidates` → `opendata_judge_candidates` (645): search by full name or gender; ordered by rank position. Includes test/practical/total scores and approval/expiry dates.

Excluded: `opendata_corruption_offenders` (overlaps `corruption_register`).

<sup>Written for commit 28852518d1e7890a300d37f281e3d24d8eb0412d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

