### PR TITLE
fix(billing): price the 12 unpriced tools added to the v2 curated set

### DIFF
--- a/mcp_backend/src/migrations/184_v2_ua_opendata_tool_pricing.sql
+++ b/mcp_backend/src/migrations/184_v2_ua_opendata_tool_pricing.sql
@@ -1,0 +1,34 @@
+-- Migration 184: pricing for the Ukrainian open-data tools added to the v2 curated set.
+--
+-- PR #2254 grew V2_TOOL_NAMES (curated-mcp-tools.ts) from 28 to 51 tools. /api/v2/mcp bills
+-- per call from the ₴/$ balance, so every exposed tool needs a tool_pricing row — without one
+-- the call falls through to whatever default the billing layer applies (same gap migration 175
+-- closed for the original 28). 11 of the 23 new names were already priced; these are the other 12.
+--
+-- Scale follows the post-migration-139 (reduced) tiers, matched to sibling tools:
+--   * single-record lookups            -> $0.0001 (like get_legislation_section)
+--   * plain registry/table searches    -> $0.0003 (like search_judges, search_vkks)
+--   * heavy multi-query / fuzzy search -> $0.0005 (like search_registry, openreyestr_search_entities)
+
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes)
+VALUES
+  -- Відкриті дані України — локальні хендлери
+  ('search_edrnpa',                        'backend',     'Пошук НПА в ЄДРНПА',                 0.00030000, '141K карток Мін''юсту, як search_judges'),
+  ('search_court_case_status',             'backend',     'Стан розгляду судових справ',        0.00030000, '1.25M записів, лише Верховний Суд'),
+  ('search_court_hearing_schedule',        'backend',     'Розклад судових засідань',           0.00030000, '481K записів'),
+  ('search_invalid_passports',             'backend',     'Перевірка недійсних паспортів',      0.00030000, '2.89M + 195K закордонних'),
+  ('search_public_spending',               'backend',     'Пошук у публічних коштах (Є-Data)',  0.00050000, '8.8M актів + 2M додатків, важкий скан'),
+  -- Інтелектуальна власність
+  ('search_ip_objects',                    'backend',     'Пошук об''єктів права ІВ',           0.00050000, 'ip_objects 820K, як search_registry'),
+  ('get_ip_object',                        'backend',     'Картка об''єкта права ІВ',           0.00010000, 'Один запис + таймлайн подій'),
+  ('get_trademark_dossier',                'backend',     'Досьє торговельної марки',           0.00050000, 'Кілька запитів + події, найважчий з ІВ-інструментів'),
+  ('find_similar_trademarks',              'backend',     'Пошук схожих торговельних марок',    0.00050000, 'pg_trgm колізії в межах класу'),
+  -- ЄДР — решта OpenReyestr
+  ('openreyestr_search_tax_debt',          'openreyestr', 'Податковий борг',                    0.00030000, '861K записів, як інші openreyestr-пошуки'),
+  ('openreyestr_search_esv_debt',          'openreyestr', 'Борг з ЄСВ',                         0.00030000, '668K записів'),
+  ('openreyestr_search_single_tax_payers', 'openreyestr', 'Платники єдиного податку',           0.00030000, '152K записів')
+ON CONFLICT (tool_name) DO UPDATE SET
+  base_cost_usd = EXCLUDED.base_cost_usd,
+  display_name = EXCLUDED.display_name,
+  service = EXCLUDED.service,
+  notes = EXCLUDED.notes;


### PR DESCRIPTION
## Навіщо

`/api/v2/mcp` тарифікує кожен виклик з ₴/$-балансу, тому кожен інструмент на цьому ендпоінті потребує рядка в `tool_pricing`. Без нього виклик провалюється в дефолт біллінг-шару.

Міграція 175 закрила рівно цю дірку для початкових 28 інструментів. PR #2254 розширив набір до 51 і відкрив її знову.

Перевірив усі 23 нові назви на проді: **11 уже мали ціну** (чотири `rada_*`, три `openreyestr_*`, `openreyestr_get_statistics`, `search_judges`, `search_vkks`, `search_vrp_judges_discipline`). Це решта **12**.

## Ціни

Шкала post-139 (знижена), за аналогією з сусідніми інструментами:

| Тариф | Інструменти |
|---|---|
| $0.0001 — картка одного запису | `get_ip_object` |
| $0.0003 — простий пошук по таблиці | `search_edrnpa`, `search_court_case_status`, `search_court_hearing_schedule`, `search_invalid_passports`, `openreyestr_search_tax_debt`, `_esv_debt`, `_single_tax_payers` |
| $0.0005 — важкий / багатозапитний | `search_public_spending`, `search_ip_objects`, `get_trademark_dossier`, `find_similar_trademarks` |

У верхньому тарифі `get_trademark_dossier` і `search_public_spending` не випадково: обидва я заміряв на проді — **37.7 с** і **25.9 с** відповідно, обидва розгортаються в кілька запитів.

## Перевірка

Міграцію прогнано проти **реальної схеми прода** всередині транзакції з `ROLLBACK`:

```
BEGIN
INSERT 0 12
get_trademark_dossier       | 0.00050000 | backend
openreyestr_search_tax_debt | 0.00030000 | openreyestr
search_edrnpa               | 0.00030000 | backend
ROLLBACK
```

Помилок немає, гілка `ON CONFLICT DO UPDATE` ціла. Застосується через CI/CD, не руками.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets pricing for 12 previously unpriced tools in the v2 curated set so `/api/v2/mcp` bills them correctly instead of falling back to default billing. Prices follow the reduced post-139 tiers.

- **Migration**
  - Adds migration 184 inserting/updating 12 `tool_pricing` rows.
  - Tiers: $0.0001 single-record (`get_ip_object`); $0.0003 simple searches (e.g., `search_edrnpa`, `search_court_case_status`, `openreyestr_search_tax_debt`); $0.0005 heavy/fan-out (`search_public_spending`, `get_trademark_dossier`, `find_similar_trademarks`, `search_ip_objects`).
  - Idempotent via ON CONFLICT DO UPDATE; validated against prod schema in a rolled-back transaction.

<sup>Written for commit 8fcbee8d8e4cb677c1eb99ed74abaa6b49201baa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

