### PR TITLE
feat(npa): expose the full 293K-act Ukrainian legislation corpus

### DIFF
--- a/mcp_backend/src/api/__tests__/npa-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/npa-tools.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the full-НПА-corpus tools.
+ *
+ * Focus is on the things that silently produce wrong output rather than throwing:
+ * dictionary decoding (types_raw is pipe-separated multi-value), the temporal edition
+ * branch, and the TOAST-safe / chrome-stripped text paths.
+ */
+
+import { NpaTools } from '../tools/npa-tools.js';
+import { docTypeIdFromLabel, docTypeLabels, npaUrl, statusLabel } from '../tools/npa-dicts.js';
+
+jest.mock('../../utils/logger.js', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+const ACT_ROW = {
+  nreg: '2755-17',
+  title: 'Податковий кодекс України',
+  status_code: 5,
+  types_raw: '21|1|124',
+  editions_cnt: 241,
+  texts_cnt: 241,
+  has_articles: true,
+  first_ed: '2010-12-02',
+  last_ed: '2026-01-01',
+};
+
+function parse(result: any) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('npa-dicts', () => {
+  it('decodes status codes', () => {
+    expect(statusLabel(5)).toBe('Чинний');
+    expect(statusLabel(1)).toBe('Втратив чинність');
+    expect(statusLabel(null)).toBe('Не визначено');
+  });
+
+  it('treats types_raw as a pipe-separated multi-value field', () => {
+    expect(docTypeLabels('21|1|124')).toEqual(['Кодекс України', 'Закон', 'Кодекс']);
+    expect(docTypeLabels('2')).toEqual(['Постанова']);
+    expect(docTypeLabels(null)).toEqual([]);
+    // unknown ids are dropped, not rendered as "Код N"
+    expect(docTypeLabels('2|99999')).toEqual(['Постанова']);
+  });
+
+  it('maps doc-type labels case-insensitively, preferring the shortest prefix match', () => {
+    expect(docTypeIdFromLabel('Закон')).toBe(1);
+    expect(docTypeIdFromLabel('постанова')).toBe(2);
+    expect(docTypeIdFromLabel('кодекс')).toBe(124); // "Кодекс" beats "Кодекс України"
+    expect(docTypeIdFromLabel('нісенітниця')).toBeNull();
+  });
+
+  it('links to a historical edition only when one is shown', () => {
+    expect(npaUrl('435-15')).toBe('https://zakon.rada.gov.ua/laws/show/435-15');
+    expect(npaUrl('435-15', '2022-05-27', false)).toBe('https://zakon.rada.gov.ua/laws/show/435-15/ed20220527');
+    expect(npaUrl('435-15', '2026-01-01', true)).toBe('https://zakon.rada.gov.ua/laws/show/435-15');
+  });
+});
+
+describe('get_npa_act', () => {
+  let db: { query: jest.Mock };
+  let tools: NpaTools;
+
+  beforeEach(() => {
+    db = { query: jest.fn() };
+    tools = new NpaTools(db);
+  });
+
+  it('resolves the edition in force on as_of_date, not the current one', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ nreg: '2755-17' }] })                        // resolveNreg
+      .mockResolvedValueOnce({ rows: [ACT_ROW] })                                    // act card
+      .mockResolvedValueOnce({ rows: [{ ed_date: '2022-05-27', is_current: false }] }) // resolveEdition
+      .mockResolvedValueOnce({ rows: [{ article_count: 0, char_len: 123 }] });
+
+    const out = parse(await tools.executeTool('get_npa_act', { nreg: '2755-17', as_of_date: '2022-06-01' }));
+
+    expect(out.shown_edition).toBe('2022-05-27');
+    expect(out.is_current).toBe(false);
+    expect(out.url).toBe('https://zakon.rada.gov.ua/laws/show/2755-17/ed20220527');
+    // the temporal branch must be the ed_date <= $2 one
+    const editionSql = db.query.mock.calls[2][0];
+    expect(editionSql).toContain('ed_date <= $2::date');
+    expect(db.query.mock.calls[2][1]).toEqual(['2755-17', '2022-06-01']);
+  });
+
+  it('uses the is_current branch when no date is given', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ nreg: '2755-17' }] })
+      .mockResolvedValueOnce({ rows: [ACT_ROW] })
+      .mockResolvedValueOnce({ rows: [{ ed_date: '2026-01-01', is_current: true }] })
+      .mockResolvedValueOnce({ rows: [{ article_count: 2, char_len: 9 }] });
+
+    const out = parse(await tools.executeTool('get_npa_act', { nreg: '2755-17' }));
+
+    expect(db.query.mock.calls[2][0]).toContain('is_current');
+    expect(out.status).toBe('Чинний');
+    expect(out.doc_types).toEqual(['Кодекс України', 'Закон', 'Кодекс']);
+  });
+
+  it('reports an unknown act instead of throwing', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] });
+    const out = await tools.executeTool('get_npa_act', { nreg: 'не-існує' });
+    expect(out!.content[0].text).toContain('не знайдено');
+  });
+
+  it('rejects a malformed as_of_date before touching the database', async () => {
+    const out = await tools.executeTool('get_npa_act', { nreg: '2755-17', as_of_date: '01.06.2022' });
+    expect(out!.content[0].text).toContain('YYYY-MM-DD');
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('never slices a TOASTed body directly and strips the page chrome', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ nreg: '254к/96-вр' }] })
+      .mockResolvedValueOnce({ rows: [{ ...ACT_ROW, nreg: '254к/96-вр', title: 'Конституція України' }] })
+      .mockResolvedValueOnce({ rows: [{ ed_date: '2020-01-01', is_current: true }] })
+      .mockResolvedValueOnce({ rows: [{ total_chars: 136113, text: 'КОНСТИТУЦІЯ УКРАЇНИ' }] });
+
+    const out = parse(await tools.executeTool('get_npa_act', { nreg: '254к/96-вр', mode: 'text' }));
+
+    const textSql = db.query.mock.calls[3][0];
+    // The table column must be fully detoasted in the innermost subquery; slicing
+    // npa.edition_text.body directly raises UTF8 errors on ~30% of rows. Every later
+    // substr() in this statement reads the already-materialised CTE column, not the table.
+    expect(textSql).toMatch(/FROM \(SELECT body \|\| '' AS b FROM npa\.edition_text/);
+    expect(textSql).toContain('mouse wheel');
+    expect(out.total_chars).toBe(136113);
+    // first page of a 136k-char act — the caller must know to page on
+    expect(out.has_more).toBe(true);
+    expect(out.offset).toBe(0);
+  });
+
+  it('does not offer a table of contents for an act with no article layer', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ nreg: '148-2003-п' }] })
+      .mockResolvedValueOnce({ rows: [{ ...ACT_ROW, nreg: '148-2003-п', has_articles: false }] })
+      .mockResolvedValueOnce({ rows: [{ ed_date: '2020-01-01', is_current: true }] });
+
+    const out = parse(await tools.executeTool('get_npa_act', { nreg: '148-2003-п', mode: 'toc' }));
+    expect(out.note).toContain('mode=text');
+  });
+});
+
+describe('search_npa', () => {
+  let db: { query: jest.Mock };
+  let tools: NpaTools;
+
+  beforeEach(() => {
+    db = { query: jest.fn() };
+    tools = new NpaTools(db);
+  });
+
+  it('requires query or title', async () => {
+    const out = await tools.executeTool('search_npa', {});
+    expect(out!.content[0].text).toContain('query');
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('excludes repealed acts by default and never ranks on document bodies', async () => {
+    db.query.mockResolvedValue({
+      rows: [{ ...ACT_ROW, _total_count: 190, shown_edition: '2026-01-01', shown_is_current: true, snippet: 'фрагмент' }],
+    });
+
+    const out = parse(await tools.executeTool('search_npa', { query: 'відстрочка від мобілізації' }));
+
+    const sql = db.query.mock.calls[0][0];
+    expect(sql).toContain('t.is_current');            // required to hit the partial FTS index
+    expect(sql).not.toContain('ts_rank');             // ~8s over full bodies — must stay out
+    expect(sql).toContain("body || ''");              // TOAST-safe snippet
+    expect(out.results[0].status).toBe('Чинний');
+    expect(out.total_count_at_least).toBe(190);
+    expect(out.capped).toBe(false);
+  });
+
+  it('relaxes an over-strict AND query to OR only when the strict pass is thin', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ ...ACT_ROW, _total_count: 1, shown_edition: '2026-01-01', shown_is_current: true, snippet: 'x' }] })
+      .mockResolvedValueOnce({
+        rows: [1, 2, 3, 4].map(() => ({ ...ACT_ROW, _total_count: 4, shown_edition: '2026-01-01', shown_is_current: true, snippet: 'x' })),
+      });
+
+    const out = parse(await tools.executeTool('search_npa', { query: 'відстрочка від мобілізації' }));
+
+    expect(db.query.mock.calls[0][1][0]).toContain(' & ');
+    expect(db.query.mock.calls[1][1][0]).toContain(' | ');
+    expect(out.note).toContain('пом’якшений');
+    expect(out.results).toHaveLength(4);
+  });
+
+  it('rejects an unknown doc_type instead of silently ignoring it', async () => {
+    const out = await tools.executeTool('search_npa', { query: 'податок', doc_type: 'Мандат' });
+    expect(out!.content[0].text).toContain('Невідомий тип документа');
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a query with no usable content tokens', async () => {
+    const out = await tools.executeTool('search_npa', { query: 'та і в на' });
+    expect(out!.content[0].text).toContain('придатних для пошуку');
+    expect(db.query).not.toHaveBeenCalled();
+  });
+});

--- a/mcp_backend/src/api/curated-mcp-tools.ts
+++ b/mcp_backend/src/api/curated-mcp-tools.ts
@@ -27,6 +27,9 @@ export const V2_TOOL_NAMES = new Set<string>([
   'get_legislation_structure',
   'get_legislation_history',
   'list_legislation_editions',
+  // Повний корпус НПА (schema `npa`) — 293K актів / 439K редакцій, поза кураторськими ~655
+  'search_npa',
+  'get_npa_act',
   // Court decisions — ЄДРСР (9)
   'search_court_decisions',
   'get_court_decision',

--- a/mcp_backend/src/api/tools/npa-dicts.ts
+++ b/mcp_backend/src/api/tools/npa-dicts.ts
@@ -1,0 +1,97 @@
+/**
+ * Rada dictionary codes for the full НПА corpus (schema `npa`).
+ *
+ * `npa.act.status_code` and `npa.act.types_raw` hold raw Rada dictionary ids. The
+ * dictionaries themselves (stan.txt / typ.txt) were loaded into the separate `rada_npa`
+ * working database during the harvest, so they are NOT joinable from `secondlayer_prod`
+ * — hence the hardcoded maps here.
+ *
+ * types_raw is a pipe-separated MULTI-value field ("2|125"): an act can carry several
+ * type ids at once, so match it as a list, never with equality.
+ */
+
+export const NPA_STATUS: Record<number, string> = {
+  0: 'Не визначено',
+  1: 'Втратив чинність',
+  2: 'Набирає чинності',
+  3: 'Дію зупинено',
+  4: 'Дію відновлено',
+  5: 'Чинний',
+  6: 'Не набрав чинності',
+  7: 'Не застосовується на території України',
+  8: 'Частково набрав чинності',
+  9: 'Втратив чинність крім окремих положень',
+};
+
+/** Status codes that mean "no longer in force" — filtered out unless explicitly asked for. */
+export const NPA_REPEALED_CODES = [1, 9];
+
+/** Accepted values of the `status` tool argument → status_code. */
+export const NPA_STATUS_ARG: Record<string, number> = {
+  'чинний': 5,
+  'втратив чинність': 1,
+  'набирає чинності': 2,
+  'не набрав чинності': 6,
+};
+
+export const NPA_DOC_TYPE: Record<number, string> = {
+  1: 'Закон',
+  2: 'Постанова',
+  3: 'Указ',
+  6: 'Розпорядження',
+  9: 'Наказ',
+  11: 'Положення',
+  12: "Роз'яснення",
+  15: 'Лист',
+  17: 'Угода',
+  18: 'Протокол',
+  20: 'Конвенція',
+  21: 'Кодекс України',
+  22: 'Рішення',
+  30: 'Ухвала',
+  32: 'Регламент',
+  44: 'Рекомендації',
+  52: 'Резолюція',
+  95: 'Повідомлення',
+  100: 'Конституція',
+  124: 'Кодекс',
+  130: 'Статус',
+  216: 'Конституція України',
+};
+
+/** Label → doc-type id, for the `doc_type` tool argument (case-insensitive). */
+const DOC_TYPE_BY_LABEL: Record<string, number> = Object.entries(NPA_DOC_TYPE).reduce(
+  (acc, [id, label]) => { acc[label.toLowerCase()] = Number(id); return acc; },
+  {} as Record<string, number>
+);
+
+export function docTypeIdFromLabel(label: string): number | null {
+  const key = String(label || '').trim().toLowerCase();
+  if (!key) return null;
+  if (DOC_TYPE_BY_LABEL[key] !== undefined) return DOC_TYPE_BY_LABEL[key];
+  // "кодекс" should also find "Кодекс України"; take the shortest label that starts with it.
+  const hit = Object.keys(DOC_TYPE_BY_LABEL)
+    .filter((l) => l.startsWith(key))
+    .sort((a, b) => a.length - b.length)[0];
+  return hit ? DOC_TYPE_BY_LABEL[hit] : null;
+}
+
+export function statusLabel(code: number | null | undefined): string {
+  return code == null ? 'Не визначено' : (NPA_STATUS[code] ?? `Код ${code}`);
+}
+
+/** types_raw ("2|125") → readable labels ["Постанова", …]. Unknown ids are dropped. */
+export function docTypeLabels(typesRaw: string | null | undefined): string[] {
+  return String(typesRaw || '')
+    .split('|')
+    .map((t) => Number(t.trim()))
+    .filter((n) => Number.isInteger(n) && NPA_DOC_TYPE[n] !== undefined)
+    .map((n) => NPA_DOC_TYPE[n]);
+}
+
+/** zakon.rada.gov.ua permalink; a historical edition gets the /ed{YYYYMMDD} suffix. */
+export function npaUrl(nreg: string, edDate?: string | null, isCurrent = true): string {
+  const base = `https://zakon.rada.gov.ua/laws/show/${nreg}`;
+  if (!edDate || isCurrent) return base;
+  return `${base}/ed${edDate.replace(/-/g, '')}`;
+}

--- a/mcp_backend/src/api/tools/npa-tools.ts
+++ b/mcp_backend/src/api/tools/npa-tools.ts
@@ -1,0 +1,448 @@
+/**
+ * НПА corpus tools — the FULL Ukrainian legislation registry (schema `npa`).
+ *
+ * Distinct from the six search_legislation/get_legislation_* tools, which serve the
+ * curated `public.legislation` set (~655 acts with a parsed article hierarchy). This
+ * handler serves the complete zakon.rada.gov.ua harvest: 293K acts, 439K editions,
+ * 2.2M articles, with every historical edition addressable by date.
+ *
+ * ⚠ TOAST SLICE HAZARD (PG 15.16 + pglz). Slicing `npa.edition_text.body` or
+ * `npa.article.body` DIRECTLY — left(body, n), substr(body, …) — raises
+ * "invalid byte sequence for encoding UTF8" non-deterministically on the partial-detoast
+ * path. Measured on prod: left(body,200) failed on 98 of 300 current editions (33%),
+ * while substr(body || '', 1, 200) succeeded on 300 of 300. The stored bytes are valid;
+ * the partial detoast is what breaks. EVERY slice below therefore forces a full detoast
+ * with `body || ''` first. Do not "simplify" that away.
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { legislationStems } from '../../services/legislation-search-utils.js';
+import {
+  NPA_REPEALED_CODES,
+  NPA_STATUS_ARG,
+  docTypeIdFromLabel,
+  docTypeLabels,
+  npaUrl,
+  statusLabel,
+} from './npa-dicts.js';
+import { logger } from '../../utils/logger.js';
+
+/** Candidate cap for the FTS leg — total_found is a lower bound, never exact. */
+const FTS_CANDIDATE_CAP = 2000;
+/** Same ceiling get_legislation_section uses for a single text payload. */
+const MAX_TEXT_CHARS = 60000;
+
+/**
+ * zakon.rada page chrome that the harvester kept at the head of the body:
+ * "Друкувати / Допомога / Шрифт: / + збільшити / − зменшити / або Ctrl + mouse wheel".
+ * Measured on prod: 2340 of 3000 sampled current editions (78%) start with it, always
+ * ending at the same offset. Article bodies are clean — the article parser already skips it.
+ *
+ * SQL form, applied BEFORE slicing so `offset` and `total_chars` describe the real text.
+ * `b` must already be fully detoasted by the caller (see the TOAST note above).
+ */
+const STRIP_CHROME_SQL = `CASE
+    WHEN b LIKE 'Друкувати%' AND strpos(substr(b, 1, 200), 'mouse wheel') > 0
+      THEN substr(b, strpos(substr(b, 1, 200), 'mouse wheel') + 12)
+    ELSE b
+  END`;
+
+/** Cosmetic same-strip for snippets, where the match can land inside the chrome block. */
+function stripChrome(text: string | null | undefined): string {
+  const s = String(text ?? '');
+  const i = s.indexOf('mouse wheel');
+  return s.startsWith('Друкувати') && i >= 0 ? s.slice(i + 12) : s;
+}
+
+export class NpaTools extends BaseToolHandler {
+  constructor(private db: any) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'search_npa',
+        annotations: { title: 'Повний корпус НПА України', readOnlyHint: true },
+        description: `Пошук по ПОВНОМУ корпусу нормативно-правових актів України
+
+293K актів · 439K редакцій · 2.2M статей — весь реєстр zakon.rada.gov.ua.
+Це НЕ те саме, що search_legislation: там ~655 кодексів і базових законів з розібраною структурою статей, тут — уся нормативна база, включно з постановами КМУ, наказами міністерств, указами, листами й роз'ясненнями.
+
+Два режими (взаємовиключні):
+• query — повнотекстовий пошук по тексту актів
+• title — пошук за назвою акта (нечіткий, триграми)
+
+Фільтри: status (типово «чинний»), doc_type (Закон, Кодекс, Постанова, Указ, Наказ…), as_of_date.
+
+ВАЖЛИВО: пошук завжди виконується по ЧИННИХ редакціях (історичні редакції не мають повнотекстового індексу). Параметр as_of_date не змінює те, ЩО знайдено — він змінює, з якої редакції показано фрагмент.
+Далі: get_npa_act для картки, переліку редакцій, статей або повного тексту.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Пошуковий запит по тексту актів' },
+            title: { type: 'string', description: 'Пошук за назвою акта (нечіткий)' },
+            status: {
+              type: 'string',
+              enum: ['чинний', 'втратив чинність', 'набирає чинності', 'не набрав чинності', 'будь-який'],
+              default: 'чинний',
+              description: 'Стан акта. Типово «чинний» — інакше у видачу потрапляють скасовані акти',
+            },
+            doc_type: { type: 'string', description: 'Тип документа: Закон, Кодекс, Постанова, Указ, Наказ, Розпорядження, Рішення, Лист тощо' },
+            as_of_date: { type: 'string', description: 'Дата (YYYY-MM-DD) — фрагмент показується з редакції, чинної на цю дату' },
+            limit: { type: 'number', default: 20, maximum: 50, description: 'Макс. результатів' },
+          },
+        },
+      },
+      {
+        name: 'get_npa_act',
+        annotations: { title: 'Картка, редакції та текст акта НПА', readOnlyHint: true },
+        description: `Картка нормативно-правового акта з повного корпусу НПА, його редакції та текст
+
+Режими (mode):
+• card (типово) — назва, стан, тип, кількість редакцій, перша й остання редакція
+• editions — перелік усіх редакцій з датами
+• toc — перелік статей редакції (лише для структурованих актів, has_articles=true)
+• article — текст конкретної статті (потрібен article_number)
+• text — повний текст редакції посторінково (offset)
+
+Часова машина: as_of_date повертає редакцію, чинну на вказану дату. Наприклад Податковий кодекс станом на 2022-06-01 — це редакція від 2022-05-27, а не сьогоднішня.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            nreg: { type: 'string', description: 'Реєстраційний номер акта: 2755-17, 254к/96-вр, z0567-01' },
+            mode: { type: 'string', enum: ['card', 'editions', 'toc', 'article', 'text'], default: 'card', description: 'Режим' },
+            article_number: { type: 'string', description: 'Номер статті для mode=article, напр. 625 або 205-1' },
+            as_of_date: { type: 'string', description: 'Дата (YYYY-MM-DD) — редакція, чинна на цю дату' },
+            offset: { type: 'number', default: 0, description: 'Зсув у символах для mode=text' },
+            limit: { type: 'number', default: 50, maximum: 200, description: 'Ліміт редакцій або статей' },
+          },
+          required: ['nreg'],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
+    switch (name) {
+      case 'search_npa': return this.searchNpa(args);
+      case 'get_npa_act': return this.getNpaAct(args);
+      default: return null;
+    }
+  }
+
+  // ─── helpers ────────────────────────────────────────────────────────
+
+  /** Resolve the act id as stored: exact PK hit first, case-insensitive fallback. */
+  private async resolveNreg(input: string): Promise<string | null> {
+    const raw = String(input || '').trim();
+    if (!raw) return null;
+    const exact = await this.db.query('SELECT nreg FROM npa.act WHERE nreg = $1', [raw]);
+    if (exact.rows.length > 0) return exact.rows[0].nreg;
+    const ci = await this.db.query('SELECT nreg FROM npa.act WHERE lower(nreg) = lower($1) LIMIT 1', [raw]);
+    return ci.rows.length > 0 ? ci.rows[0].nreg : null;
+  }
+
+  /**
+   * Edition in force for an act on a date (or the current one when no date is given).
+   * Two explicit branches so each uses its own partial index — edition_current and
+   * edition_temporal. Only http_status=200 editions have text.
+   */
+  private async resolveEdition(nreg: string, asOfDate?: string): Promise<{ ed_date: string; is_current: boolean } | null> {
+    if (asOfDate) {
+      const r = await this.db.query(
+        `SELECT to_char(ed_date, 'YYYY-MM-DD') AS ed_date, is_current
+           FROM npa.edition
+          WHERE nreg = $1 AND http_status = 200 AND ed_date <= $2::date
+          ORDER BY ed_date DESC LIMIT 1`,
+        [nreg, asOfDate]
+      );
+      return r.rows[0] ?? null;
+    }
+    const r = await this.db.query(
+      `SELECT to_char(ed_date, 'YYYY-MM-DD') AS ed_date, is_current
+         FROM npa.edition
+        WHERE nreg = $1 AND is_current AND http_status = 200 LIMIT 1`,
+      [nreg]
+    );
+    return r.rows[0] ?? null;
+  }
+
+  private statusFilter(status: string | undefined): { code: number | null; excludeRepealed: boolean } {
+    const s = String(status ?? 'чинний').trim().toLowerCase();
+    if (s === 'будь-який') return { code: null, excludeRepealed: false };
+    const code = NPA_STATUS_ARG[s];
+    if (code !== undefined) return { code, excludeRepealed: false };
+    return { code: null, excludeRepealed: true };
+  }
+
+  private shapeAct(row: any, extra: Record<string, unknown> = {}): Record<string, unknown> {
+    const edDate = (extra.shown_edition as string) ?? null;
+    const isCurrent = extra.is_current === undefined ? true : Boolean(extra.is_current);
+    return {
+      nreg: row.nreg,
+      title: row.title,
+      status: statusLabel(row.status_code),
+      doc_types: docTypeLabels(row.types_raw),
+      editions_count: row.editions_cnt,
+      has_articles: row.has_articles,
+      first_edition: row.first_ed,
+      last_edition: row.last_ed,
+      ...extra,
+      url: npaUrl(row.nreg, edDate, isCurrent),
+    };
+  }
+
+  // ─── search_npa ─────────────────────────────────────────────────────
+
+  private async searchNpa(args: Record<string, unknown>): Promise<ToolResult> {
+    const { query, title, status, doc_type, as_of_date, limit = 20 } = args as any;
+    if (!query && !title) {
+      return this.wrapResponse('Вкажіть query (пошук по тексту актів) або title (пошук за назвою).');
+    }
+    const lim = Math.min(Number(limit) || 20, 50);
+    const { code: statusCode, excludeRepealed } = this.statusFilter(status);
+    const docTypeId = doc_type ? docTypeIdFromLabel(String(doc_type)) : null;
+    if (doc_type && docTypeId === null) {
+      return this.wrapResponse(`Невідомий тип документа «${doc_type}». Спробуйте: Закон, Кодекс, Постанова, Указ, Наказ, Розпорядження, Рішення, Лист.`);
+    }
+    if (as_of_date && !/^\d{4}-\d{2}-\d{2}$/.test(String(as_of_date))) {
+      return this.wrapResponse('as_of_date має бути у форматі YYYY-MM-DD.');
+    }
+
+    try {
+      return title
+        ? await this.searchNpaByTitle(String(title), statusCode, excludeRepealed, docTypeId, lim)
+        : await this.searchNpaByText(String(query), statusCode, excludeRepealed, docTypeId, as_of_date, lim);
+    } catch (error: any) {
+      logger.error('search_npa error', { error: error.message });
+      return this.wrapError(`Помилка пошуку по корпусу НПА: ${error.message}`);
+    }
+  }
+
+  private actFilterSql(statusCode: number | null, excludeRepealed: boolean, docTypeId: number | null, values: any[], startIdx: number): { sql: string; nextIdx: number } {
+    const parts: string[] = [];
+    let pi = startIdx;
+    if (statusCode !== null) { parts.push(`a.status_code = $${pi}`); values.push(statusCode); pi++; }
+    else if (excludeRepealed) { parts.push(`(a.status_code IS NULL OR a.status_code <> ALL($${pi}::int[]))`); values.push(NPA_REPEALED_CODES); pi++; }
+    if (docTypeId !== null) {
+      // types_raw is pipe-separated multi-value ("2|125") — match as a list, not by equality.
+      parts.push(`$${pi} = ANY(string_to_array(a.types_raw, '|')::int[])`);
+      values.push(docTypeId); pi++;
+    }
+    return { sql: parts.length ? `AND ${parts.join(' AND ')}` : '', nextIdx: pi };
+  }
+
+  private async searchNpaByTitle(title: string, statusCode: number | null, excludeRepealed: boolean, docTypeId: number | null, lim: number): Promise<ToolResult> {
+    const values: any[] = [title];
+    const { sql: filter, nextIdx } = this.actFilterSql(statusCode, excludeRepealed, docTypeId, values, 2);
+    values.push(lim);
+    const rows = (await this.db.query(
+      `SELECT a.nreg, a.title, a.status_code, a.types_raw, a.editions_cnt, a.has_articles,
+              to_char(a.first_ed, 'YYYY-MM-DD') AS first_ed, to_char(a.last_ed, 'YYYY-MM-DD') AS last_ed,
+              COUNT(*) OVER() AS _total_count
+         FROM npa.act a
+        WHERE a.title ILIKE '%' || $1 || '%' ${filter}
+        ORDER BY (a.status_code = 5) DESC, similarity(a.title, $1) DESC, a.last_ed DESC NULLS LAST
+        LIMIT $${nextIdx}`,
+      values
+    )).rows;
+
+    if (rows.length === 0) return this.wrapResponse('Актів із такою назвою не знайдено.');
+    return this.wrapResponse({
+      mode: 'title',
+      total_count: Number(rows[0]._total_count),
+      returned: rows.length,
+      results: rows.map((r: any) => this.shapeAct(r)),
+    });
+  }
+
+  private async searchNpaByText(query: string, statusCode: number | null, excludeRepealed: boolean, docTypeId: number | null, asOfDate: string | undefined, lim: number): Promise<ToolResult> {
+    const stems = legislationStems(query);
+    if (stems.length === 0) {
+      return this.wrapResponse('Запит не містить слів, придатних для пошуку. Додайте змістовні терміни.');
+    }
+    const anchor = stems[0];
+
+    // AND first. OR-of-prefixes over 429K editions matches almost everything, so it is a
+    // fallback for a thin result set, not the default (same relax pattern as the ГНЕУ search).
+    let rows = await this.ftsCandidates(stems, ' & ', statusCode, excludeRepealed, docTypeId, asOfDate, anchor, lim);
+    let relaxed = false;
+    if (rows.length < 3 && stems.length > 1) {
+      const orRows = await this.ftsCandidates(stems, ' | ', statusCode, excludeRepealed, docTypeId, asOfDate, anchor, lim);
+      if (orRows.length > rows.length) { rows = orRows; relaxed = true; }
+    }
+
+    if (rows.length === 0) return this.wrapResponse('У корпусі НПА нічого не знайдено за цим запитом.');
+
+    const total = Number(rows[0]._total_count);
+    return this.wrapResponse({
+      mode: 'fulltext',
+      // Candidates are capped before ranking, so the count is a floor, not an exact total.
+      total_count_at_least: total,
+      capped: total >= FTS_CANDIDATE_CAP,
+      returned: rows.length,
+      ...(relaxed ? { note: 'Строгий пошук (усі терміни) дав замало результатів — застосовано пом’якшений пошук (будь-який з термінів).' } : {}),
+      searched_over: 'чинні редакції',
+      results: rows.map((r: any) => this.shapeAct(r, {
+        shown_edition: r.shown_edition,
+        is_current: r.shown_is_current,
+        snippet: stripChrome(r.snippet),
+      })),
+    });
+  }
+
+  private async ftsCandidates(stems: string[], join: string, statusCode: number | null, excludeRepealed: boolean, docTypeId: number | null, asOfDate: string | undefined, anchor: string, lim: number): Promise<any[]> {
+    const tsquery = stems.map((s) => `${s}:*`).join(join);
+    const values: any[] = [tsquery];
+    const { sql: filter, nextIdx } = this.actFilterSql(statusCode, excludeRepealed, docTypeId, values, 2);
+    let pi = nextIdx;
+    const capIdx = pi; values.push(FTS_CANDIDATE_CAP); pi++;
+    const limIdx = pi; values.push(lim); pi++;
+    const asOfIdx = pi; values.push(asOfDate ?? null); pi++;
+    const anchorIdx = pi; values.push(anchor); pi++;
+
+    // Ranking never touches the bodies: ts_rank_cd over matched editions measured ~8s
+    // (detoast + retokenise of hundreds of MB). Ordering is on act metadata instead, and
+    // only the surviving `lim` rows get a snippet.
+    const sql = `
+      WITH cand AS (
+        SELECT t.nreg, t.ed_date
+          FROM npa.edition_text t
+         WHERE t.is_current
+           AND to_tsvector('simple', t.body) @@ to_tsquery('simple', $1)
+         LIMIT $${capIdx}
+      ),
+      ranked AS (
+        SELECT c.nreg, c.ed_date, a.title, a.status_code, a.types_raw, a.editions_cnt, a.has_articles,
+               to_char(a.first_ed, 'YYYY-MM-DD') AS first_ed, to_char(a.last_ed, 'YYYY-MM-DD') AS last_ed,
+               COUNT(*) OVER() AS _total_count
+          FROM cand c
+          JOIN npa.act a ON a.nreg = c.nreg
+         WHERE true ${filter}
+         ORDER BY (a.status_code = 5) DESC, a.last_ed DESC NULLS LAST
+         LIMIT $${limIdx}
+      )
+      SELECT r.*,
+             to_char(sel.ed_date, 'YYYY-MM-DD') AS shown_edition,
+             sel.is_current AS shown_is_current,
+             substr(t.body || '', GREATEST(1, strpos(lower(t.body), $${anchorIdx}) - 150), 400) AS snippet
+        FROM ranked r
+        CROSS JOIN LATERAL (
+          SELECT e.ed_date, e.is_current
+            FROM npa.edition e
+           WHERE e.nreg = r.nreg AND e.http_status = 200
+             AND ($${asOfIdx}::date IS NULL OR e.ed_date <= $${asOfIdx}::date)
+           ORDER BY (CASE WHEN $${asOfIdx}::date IS NULL THEN e.is_current END) DESC NULLS LAST, e.ed_date DESC
+           LIMIT 1
+        ) sel
+        JOIN npa.edition_text t ON t.nreg = r.nreg AND t.ed_date = sel.ed_date`;
+
+    return (await this.db.query(sql, values)).rows;
+  }
+
+  // ─── get_npa_act ────────────────────────────────────────────────────
+
+  private async getNpaAct(args: Record<string, unknown>): Promise<ToolResult> {
+    const { nreg, mode = 'card', article_number, as_of_date, offset = 0, limit = 50 } = args as any;
+    if (as_of_date && !/^\d{4}-\d{2}-\d{2}$/.test(String(as_of_date))) {
+      return this.wrapResponse('as_of_date має бути у форматі YYYY-MM-DD.');
+    }
+
+    try {
+      const resolved = await this.resolveNreg(String(nreg));
+      if (!resolved) return this.wrapResponse(`Акт «${nreg}» не знайдено у корпусі НПА.`);
+
+      const actRow = (await this.db.query(
+        `SELECT nreg, title, status_code, types_raw, editions_cnt, texts_cnt, has_articles,
+                to_char(first_ed, 'YYYY-MM-DD') AS first_ed, to_char(last_ed, 'YYYY-MM-DD') AS last_ed
+           FROM npa.act WHERE nreg = $1`,
+        [resolved]
+      )).rows[0];
+
+      if (mode === 'editions') {
+        const rows = (await this.db.query(
+          `SELECT to_char(ed_date, 'YYYY-MM-DD') AS ed_date, is_current, char_len, card_verified, date_suspect
+             FROM npa.edition WHERE nreg = $1 AND http_status = 200
+            ORDER BY ed_date DESC LIMIT $2`,
+          [resolved, Math.min(Number(limit) || 50, 200)]
+        )).rows;
+        return this.wrapResponse({ ...this.shapeAct(actRow), editions: rows, editions_returned: rows.length });
+      }
+
+      const edition = await this.resolveEdition(resolved, as_of_date);
+      if (!edition) {
+        return this.wrapResponse({
+          ...this.shapeAct(actRow),
+          note: as_of_date
+            ? `Для цього акта немає редакції з текстом станом на ${as_of_date}.`
+            : 'Для цього акта немає чинної редакції з текстом.',
+        });
+      }
+      const base = this.shapeAct(actRow, { shown_edition: edition.ed_date, is_current: edition.is_current });
+
+      if (mode === 'toc') {
+        if (!actRow.has_articles) {
+          return this.wrapResponse({ ...base, note: 'Цей акт не має розібраної структури статей. Використайте mode=text.' });
+        }
+        const rows = (await this.db.query(
+          `SELECT art_no, art_ord,
+                  NULLIF(btrim(split_part(title || '', E'\n', 1)), '') AS title,
+                  length(body) AS char_len
+             FROM npa.article WHERE nreg = $1 AND ed_date = $2::date
+            ORDER BY art_ord LIMIT $3`,
+          [resolved, edition.ed_date, Math.min(Number(limit) || 50, 200)]
+        )).rows;
+        return this.wrapResponse({ ...base, articles_returned: rows.length, articles: rows });
+      }
+
+      if (mode === 'article') {
+        if (!article_number) return this.wrapResponse('Для mode=article вкажіть article_number.');
+        const rows = (await this.db.query(
+          `SELECT art_no,
+                  NULLIF(btrim(split_part(title || '', E'\n', 1)), '') AS title,
+                  body || '' AS full_text, length(body) AS char_len
+             FROM npa.article WHERE nreg = $1 AND ed_date = $2::date AND art_no = $3`,
+          [resolved, edition.ed_date, String(article_number)]
+        )).rows;
+        if (rows.length === 0) {
+          return this.wrapResponse({ ...base, note: `Статтю ${article_number} не знайдено у редакції від ${edition.ed_date}. Перевірте перелік через mode=toc.` });
+        }
+        return this.wrapResponse({ ...base, article: rows[0] });
+      }
+
+      if (mode === 'text') {
+        const off = Math.max(0, Number(offset) || 0);
+        const rows = (await this.db.query(
+          `WITH src AS (
+             SELECT ${STRIP_CHROME_SQL} AS body
+               FROM (SELECT body || '' AS b FROM npa.edition_text WHERE nreg = $1 AND ed_date = $4::date) d
+           )
+           SELECT length(body) AS total_chars, substr(body, $2::int + 1, $3::int) AS text FROM src`,
+          [resolved, off, MAX_TEXT_CHARS, edition.ed_date]
+        )).rows;
+        if (rows.length === 0) return this.wrapResponse({ ...base, note: 'Текст цієї редакції відсутній.' });
+        const total = Number(rows[0].total_chars);
+        return this.wrapResponse({
+          ...base,
+          total_chars: total,
+          offset: off,
+          returned_chars: (rows[0].text || '').length,
+          has_more: off + (rows[0].text || '').length < total,
+          text: rows[0].text,
+        });
+      }
+
+      // card
+      const counts = (await this.db.query(
+        `SELECT (SELECT count(*) FROM npa.article ar WHERE ar.nreg = $1 AND ar.ed_date = $2::date) AS article_count,
+                (SELECT e.char_len FROM npa.edition e WHERE e.nreg = $1 AND e.ed_date = $2::date) AS char_len`,
+        [resolved, edition.ed_date]
+      )).rows[0];
+      return this.wrapResponse({ ...base, article_count: Number(counts.article_count), char_len: counts.char_len });
+    } catch (error: any) {
+      logger.error('get_npa_act error', { error: error.message });
+      return this.wrapError(`Помилка отримання акта НПА: ${error.message}`);
+    }
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -28,6 +28,7 @@ import { NextcloudService } from '../services/nextcloud-service.js';
 import { NextcloudTools } from '../api/tools/nextcloud-tools.js';
 import { CourtStatusTools } from '../api/tools/court-status-tools.js';
 import { OpenDataTools } from '../api/tools/opendata-tools.js';
+import { NpaTools } from '../api/tools/npa-tools.js';
 import { SpendingTools } from '../api/tools/spending-tools.js';
 import { OpenDataRegistriesTools } from '../api/tools/opendata-registries-tools.js';
 import { Tier1OpenDataTools } from '../api/tools/tier1-opendata-tools.js';
@@ -175,6 +176,8 @@ export function createToolServices(
   toolRegistry.registerHandler(new AnalyzeDataTool(coreServices.db));
   // Bespoke tools with non-parametric query patterns
   toolRegistry.registerHandler(new OpenDataTools(coreServices.db));
+  // Full НПА corpus (schema `npa`) — 293K acts, distinct from the ~655 curated legislation acts
+  toolRegistry.registerHandler(new NpaTools(coreServices.db));
   toolRegistry.registerHandler(new SpendingTools(coreServices.db));
   toolRegistry.registerHandler(new OpenDataRegistriesTools(coreServices.db));
   toolRegistry.registerHandler(new Tier1OpenDataTools(coreServices.db));

--- a/mcp_backend/src/migrations/185_npa_corpus_tool_pricing.sql
+++ b/mcp_backend/src/migrations/185_npa_corpus_tool_pricing.sql
@@ -1,0 +1,18 @@
+-- Migration 185: pricing for the full-НПА-corpus tools (search_npa, get_npa_act).
+--
+-- Both are exposed on /api/v2/mcp, which bills per call from the ₴/$ balance, so each
+-- needs a tool_pricing row or it falls through to the billing layer's default.
+--
+-- search_npa runs a GIN FTS over 429K current edition texts -> priced like the other
+-- open-data searches ($0.0005). get_npa_act is a PK lookup in npa.act/edition/article
+-- -> priced like get_legislation_section ($0.0001).
+
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes)
+VALUES
+  ('search_npa',   'backend', 'Пошук у повному корпусі НПА',   0.00050000, '293K актів / 439K редакцій, GIN FTS по чинних редакціях'),
+  ('get_npa_act',  'backend', 'Картка та текст акта НПА',      0.00010000, 'PK-лукап у npa.act/edition/article, як get_legislation_section')
+ON CONFLICT (tool_name) DO UPDATE SET
+  base_cost_usd = EXCLUDED.base_cost_usd,
+  display_name = EXCLUDED.display_name,
+  service = EXCLUDED.service,
+  notes = EXCLUDED.notes;

--- a/mcp_backend/src/services/legislation-search-utils.ts
+++ b/mcp_backend/src/services/legislation-search-utils.ts
@@ -91,11 +91,20 @@ function stemToPrefix(token: string): string {
  * usable content tokens (caller must then skip the tsquery branch — to_tsquery('') errors).
  */
 export function buildLegislationTsquery(query: string): string {
+  return legislationStems(query).map((s) => `${s}:*`).join(' | ');
+}
+
+/**
+ * Content stems of a free-text query, deduped and capped — the shared basis for every
+ * tsquery we build. Exported so callers that need a different boolean join (search_npa
+ * runs AND-first over 429K editions, where OR-of-prefixes matches almost everything)
+ * don't have to re-derive the tokenisation and stemming.
+ */
+export function legislationStems(query: string): string[] {
   const tokens = (String(query || '').toLowerCase().match(/[\p{L}\p{N}]+/gu) || [])
     .filter((t) => t.length >= 3 && !UK_STOPWORDS.has(t) && !/^\d+$/.test(t))
     .slice(0, 10);
-  const stems = tokens.map(stemToPrefix).filter(Boolean);
-  return [...new Set(stems)].map((s) => `${s}:*`).join(' | ');
+  return [...new Set(tokens.map(stemToPrefix).filter(Boolean))];
 }
 
 /**


### PR DESCRIPTION
## Навіщо

Схема `npa` тримає повний харвест zakon.rada з 10.08 — **293 049 актів · 439 060 редакцій · 2 214 334 статей** — і **жоден інструмент не читав з неї жодного байта**. Шість наявних legislation-інструментів обслуговують `public.legislation`, а це ~655 кураторських актів. Усе інше (постанови КМУ, накази міністерств, укази, листи, роз'яснення) було недосяжне.

Демо EVERLEGAL 13.08: «вся нормативна база України, будь-яка редакція на будь-яку дату» замість 655 актів.

## Що додано

- **`search_npa`** — повнотекстовий пошук по чинних редакціях або нечіткий пошук за назвою; фільтри `status` / `doc_type` / `as_of_date`
- **`get_npa_act`** — `card` / `editions` / `toc` / `article` / `text`, будь-яка редакція за датою
- обидва у `V2_TOOL_NAMES`; ціни — міграція 185

## Заміряно на проді (не лише `tsc`)

| Запит | Час | Результат |
|---|---|---|
| FTS `відстро:* & мобіліза:*` | **148 мс** | 2232-12 «Про військовий обов'язок і військову службу» |
| title ILIKE + trgm + doc_type | 62 мс | Водний / Митний / Лісовий / Сімейний / Виборчий кодекси |
| редакція, чинна на дату | 1.7 мс | ПК на 2022-06-01 → редакція **2022-05-27** |
| toc Конституції | 16 мс | ст. 1, 2, 3 |
| article ЦК ст. 625 | 2.1 мс | «Відповідальність за порушення грошового зобов'язання» |
| text paging | 7.4 мс | 136 113 символів |

## Три знахідки на проді, які визначили реалізацію

**⚠ TOAST slice bug (PG 15.16 + pglz).** Зріз колонки `body` напряму кидає `invalid byte sequence for encoding "UTF8"` **недетерміновано**. Заміряно на 300 чинних редакціях:

```
direct  left(body, 200)        ok=202  bad=98   (33% падінь)
substr(body || '', 1, 200)     ok=300  bad=0
```

Байти в базі валідні — ламається саме частковий detoast. Кожен зріз тут спершу форсує повний detoast через `body || ''`. Це не косметика, і його не можна «спростити».

**⚠ Ранжувати по тілах документів не можна.** `ts_rank_cd` по знайдених редакціях — **~8 с** (detoast + ретокенізація сотень МБ), тоді як сам матч 3–11 мс. Тому: кап 2000 кандидатів → сортування по метаданих акта → сніпет лише для тих, що вижили. `total_count` віддається як **нижня межа**, а не точне число.

**⚠ 78% редакцій несуть навігаційний мотлох zakon.rada** попереду тексту — 2340 з 3000 у вибірці, завжди той самий 72-символьний блок «Друкувати / Допомога / Шрифт: / + збільшити / − зменшити / або Ctrl + mouse wheel». Зрізається **до** нарізки, щоб `offset` і `total_chars` описували справжній акт:

```
було:  136 185 символів, починається з "Друкувати"
стало: 136 113 символів, починається з "КОНСТИТУЦІЯ УКРАЇНИ"
```

Акти без цього префікса лишаються недоторканими (перевірено).

## Інші рішення

- **Скасовані акти виключено за замовчуванням.** Вони досі мають редакцію з `is_current`, тож без цього фільтра пошук «позовна давність» витягує ЦК УРСР 1963 року.
- **Коди статусів і типів** звірені з `rada_dict` у БД `rada_npa` (з `secondlayer_prod` вона не джойниться, тому мапи захардкожені). `types_raw` — pipe-separated **multi**-value (`21|1|124`), матчиться як список, не рівністю.
- **`buildLegislationTsquery` винесено на новий `legislationStems()`**, щоб `search_npa` міг з'єднувати стеми через AND: OR-of-prefixes на 429K редакцій матчить майже все. Пом'якшення до OR — лише коли строгий прохід дав < 3 рядків. Поведінка збережена: **26 наявних legislation-тестів проходять**.

## Перевірка

- 15 нових юніт-тестів + наявний whitelist-тест — **16/16 passed**
- `npx tsc --noEmit` — по цих файлах чисто
- міграція 185 прогнана проти схеми прода в транзакції з `ROLLBACK`: `INSERT 0 2`

## Свідомо НЕ зроблено в цьому PR

Векторний cutover на `legislation_full_bge_cls` (28M точок) — окремо. Виявилося, що поточний код відкидає хіти без `article_number`, а таких у колекції 93.8%, тож самий лише флип `LEG_BGE_COLLECTION` дав би мало. Це потребує окремої роботи з гідрацією і контрольним прогоном.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the full Ukrainian legislation corpus in `npa` (293K acts, 439K editions) via two new tools, unlocking everything beyond the ~655 curated acts. Adds fast, safe text access and pricing so these tools can be used in production.

- **New Features**
  - `search_npa`: full‑text over current editions or fuzzy title search; filters `status` / `doc_type` / `as_of_date`; returns a snippet from the edition in force on `as_of_date`.
  - `get_npa_act`: `card` / `editions` / `toc` / `article` / `text` for any edition by date; pagination for full text.
  - Safety and performance: TOAST‑safe slicing (`body || ''`), strip Rada page chrome before slicing, cap FTS candidates and rank on act metadata (no `ts_rank` over bodies).
  - Exposed on `v2` via `V2_TOOL_NAMES`; pricing added for both tools.

- **Refactors**
  - Extracted `legislationStems()` from `buildLegislationTsquery()` to support AND‑first search logic in `search_npa` (relaxes to OR only when needed).

<sup>Written for commit f4a9d233e58ac4c5ad0889171d77ecce180bed75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

