### PR TITLE
feat(amcu): semantic vector pipeline for АМКУ decisions

### DIFF
--- a/scripts/amcu/01_chunk_amcu.py
+++ b/scripts/amcu/01_chunk_amcu.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Stage 1: chunk АМКУ decisions out of Postgres into gzipped JSONL shards for SageMaker.
+
+`opendata_amcu_decisions` already has a GIN full-text index (`idx_amcu_dec_body`), so keyword
+search works today. What it has no way to answer is "practice about X" where X is phrased
+differently from the decision text — hence the semantic layer.
+
+Corpus, measured on prod 2026-08-12 (not quoted from an older note):
+    6 846 rows, 2 600 with a usable body_text, 66 MB of text, mean 26 586 chars.
+At 500/100 windows that is roughly 165K chunks — a single-GPU job, minutes not hours.
+
+Chunking matches the НПА corpus exactly (500 chars, 100 overlap, deterministic md5 ids) so both
+collections behave the same way and a re-run overwrites rather than duplicates.
+
+  PGHOST=127.0.0.1 PGPORT=5438 PGUSER=secondlayer PGPASSWORD=… PGDATABASE=secondlayer_prod \
+      python3 01_chunk_amcu.py --out /data/amcu/chunks
+"""
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import time
+
+import psycopg2
+
+CHUNK_SIZE, CHUNK_OVERLAP = 500, 100
+STRIDE = CHUNK_SIZE - CHUNK_OVERLAP
+# Below this a "body" is a parse artefact (a header line, an empty docx), not a decision.
+MIN_BODY_CHARS = 200
+
+
+def log(m):
+    print(f"[{time.strftime('%H:%M:%S')}] {m}", flush=True)
+
+
+def det_uuid(s):
+    h = hashlib.md5(s.encode("utf-8")).hexdigest()
+    return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+
+def ts_of(d):
+    """date → YYYYMMDD int, for Qdrant's integer range filter."""
+    return int(d.strftime("%Y%m%d")) if d else 0
+
+
+def make_chunks(text):
+    if len(text) <= CHUNK_SIZE:
+        return [(0, text)] if text.strip() else []
+    out, start, ci = [], 0, 0
+    while start < len(text):
+        out.append((ci, text[start:start + CHUNK_SIZE]))
+        start += STRIDE
+        ci += 1
+    return out
+
+
+class ShardWriter:
+    """Round-robin per CHUNK, never per document. АМКУ decisions run from a page to hundreds of
+    pages; dealing whole documents would leave one shard several times the size of the rest."""
+
+    def __init__(self, outdir, n):
+        os.makedirs(outdir, exist_ok=True)
+        self.files = [gzip.open(os.path.join(outdir, f"amcu_{j:03d}.jsonl.gz"),
+                                "wt", encoding="utf-8", compresslevel=6)
+                      for j in range(n)]
+        self.n = n
+        self.count = 0
+
+    def write(self, rec):
+        self.files[self.count % self.n].write(json.dumps(rec, ensure_ascii=False) + "\n")
+        self.count += 1
+
+    def close(self):
+        for f in self.files:
+            f.close()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="/data/amcu/chunks")
+    ap.add_argument("--shards", type=int, default=8)
+    ap.add_argument("--limit", type=int, help="smoke test: stop after N decisions")
+    a = ap.parse_args()
+
+    conn = psycopg2.connect(
+        host=os.environ.get("PGHOST", "127.0.0.1"),
+        port=int(os.environ.get("PGPORT", 5438)),
+        user=os.environ.get("PGUSER", "secondlayer"),
+        password=os.environ.get("PGPASSWORD"),
+        dbname=os.environ.get("PGDATABASE", "secondlayer_prod"),
+    )
+    cur = conn.cursor(name="amcu_stream")  # server-side cursor: 66 MB of text, streamed
+    cur.itersize = 50
+    sql = ("SELECT id, doc_kind, decision_no, decision_date, body_text "
+           "FROM opendata_amcu_decisions "
+           "WHERE body_text IS NOT NULL AND length(body_text) > %s ORDER BY id")
+    if a.limit:
+        sql += f" LIMIT {int(a.limit)}"
+    cur.execute(sql, (MIN_BODY_CHARS,))
+
+    w = ShardWriter(a.out, a.shards)
+    docs = 0
+    t0 = time.time()
+    for did, doc_kind, decision_no, decision_date, body in cur:
+        base = {
+            "amcu_id": did,
+            "doc_kind": doc_kind,
+            "decision_no": decision_no,
+            "decision_date": decision_date.isoformat() if decision_date else None,
+            "decision_date_ts": ts_of(decision_date),
+            "document_type": "amcu_decision",
+        }
+        for ci, ch in make_chunks(body):
+            w.write({
+                "id": det_uuid(f"amcu_{did}_chunk_{ci}"),
+                "text": ch,
+                "payload": dict(base, chunk_index=ci),
+            })
+        docs += 1
+        if docs % 200 == 0:
+            log(f"{docs} decisions, {w.count:,} chunks ({w.count / (time.time() - t0):.0f}/s)")
+
+    w.close()
+    cur.close()
+    conn.close()
+    log(f"done: {docs} decisions -> {w.count:,} chunks across {a.shards} shards in {a.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/amcu/02_launch_amcu_embed.py
+++ b/scripts/amcu/02_launch_amcu_embed.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Stage 2: embed the АМКУ chunks with one SageMaker job.
+
+Reuses `scripts/legislation/sagemaker/embed_entry.py` verbatim — it is already generic: it walks
+the data channel for *.jsonl.gz, reads the "text" field, CLS-pools bge-m3 in fp16 and writes one
+.f16.npy per shard to whatever --out-prefix it is given.
+
+**Pooling must stay CLS.** Prod's `tei-bge-m3` serves CLS for every user query. The 2026-07
+legislation pilot used MEAN and its documents ended up in a different space from the queries
+searching them — self-similarity 0.70-0.77 instead of 1.0. That is why the target collection is
+named `amcu_bge_cls`.
+
+One instance is enough: ~165K chunks at the measured ~307 chunks/s on A10G is about nine minutes,
+so the fleet-splitting machinery the НПА run needed is pointless here.
+
+**S3 prefix.** Everything lives under `rada-npa/amcu-decisions/` rather than a top-level `amcu/`
+because the prod EC2 role's inline policy grants object actions only under `rada-npa/*`.
+Verified both ways on 2026-08-12: a PutObject to `amcu/_probe.txt` returned AccessDenied while
+the same write under `rada-npa/` succeeded. Moving to a cleaner prefix means adding an
+`amcu-embed-s3` inline policy first, following the existing `rada-npa-s3` / `nl-embed-s3` shape.
+
+  python3 02_launch_amcu_embed.py --dry-run
+  python3 02_launch_amcu_embed.py
+"""
+import argparse
+import tarfile
+import time
+
+import boto3
+
+REGION = "eu-central-1"
+BUCKET = "secondlayer-ml-data-euc1"
+CHUNKS_PREFIX = "rada-npa/amcu-decisions/chunks"
+VECTORS_PREFIX = "rada-npa/amcu-decisions/vectors"
+CODE_PREFIX = "rada-npa/amcu-decisions/code"
+ROLE = "arn:aws:iam::272594900302:role/SageMakerDPOExecutionRole"
+IMAGE = (f"763104351884.dkr.ecr.{REGION}.amazonaws.com/"
+         "pytorch-training:2.1.0-gpu-py310-cu121-ubuntu20.04-sagemaker")
+# A10G measured at 307 chunks/s against L4's ~230 on this exact workload, and it is also the
+# cheapest per GPU-hour of the types with a non-zero quota.
+INSTANCE = "ml.g5.2xlarge"
+USD_H = 1.890
+ENTRY = "../legislation/sagemaker/embed_entry.py"
+
+
+def log(m):
+    print(f"[{time.strftime('%H:%M:%S')}] {m}", flush=True)
+
+
+def pack_code(s3, key):
+    """SageMaker wants the entry script inside a tar.gz; embed_entry.py has no local imports."""
+    tmp = "/tmp/amcu_source.tar.gz"
+    with tarfile.open(tmp, "w:gz") as t:
+        t.add(ENTRY, arcname="embed_entry.py")
+    s3.upload_file(tmp, BUCKET, key)
+    return f"s3://{BUCKET}/{key}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--batch-size", type=int, default=32)
+    a = ap.parse_args()
+
+    s3 = boto3.client("s3", region_name=REGION)
+    shards = [o["Key"] for o in
+              s3.list_objects_v2(Bucket=BUCKET, Prefix=CHUNKS_PREFIX + "/").get("Contents", [])
+              if o["Key"].endswith(".jsonl.gz")]
+    if not shards:
+        raise SystemExit(f"no shards under s3://{BUCKET}/{CHUNKS_PREFIX}/ — run 01_chunk_amcu.py first")
+    log(f"{len(shards)} shards, instance {INSTANCE} at ${USD_H}/h")
+
+    job = f"amcu-bge-cls-{time.strftime('%Y%m%d-%H%M%S')}"
+    if a.dry_run:
+        log(f"dry run — would launch {job} over {len(shards)} shards")
+        for s in shards:
+            log(f"  {s}")
+        return
+
+    code_uri = pack_code(s3, f"{CODE_PREFIX}/source.tar.gz")
+    sm = boto3.client("sagemaker", region_name=REGION)
+    sm.create_training_job(
+        TrainingJobName=job,
+        AlgorithmSpecification={"TrainingImage": IMAGE, "TrainingInputMode": "File"},
+        RoleArn=ROLE,
+        InputDataConfig=[{
+            "ChannelName": "data",
+            "DataSource": {"S3DataSource": {
+                "S3DataType": "S3Prefix",
+                "S3Uri": f"s3://{BUCKET}/{CHUNKS_PREFIX}/",
+                "S3DataDistributionType": "FullyReplicated",
+            }},
+        }],
+        OutputDataConfig={"S3OutputPath": f"s3://{BUCKET}/{CODE_PREFIX}/output"},
+        ResourceConfig={"InstanceType": INSTANCE, "InstanceCount": 1, "VolumeSizeInGB": 100},
+        StoppingCondition={"MaxRuntimeInSeconds": 7200},
+        HyperParameters={
+            "sagemaker_program": '"embed_entry.py"',
+            "sagemaker_submit_directory": f'"{code_uri}"',
+            "out-bucket": f'"{BUCKET}"',
+            "out-prefix": f'"{VECTORS_PREFIX}"',
+            "batch-size": str(a.batch_size),
+        },
+    )
+    log(f"launched {job}")
+    log(f"  aws sagemaker describe-training-job --training-job-name {job} "
+        f"--region {REGION} --query TrainingJobStatus")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/amcu/03_upsert_amcu_vectors.py
+++ b/scripts/amcu/03_upsert_amcu_vectors.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Stage 3: load the embedded АМКУ decisions into Qdrant as `amcu_bge_cls`.
+
+Same shape as `scripts/legislation/sagemaker/upsert_legislation_vectors.py`: vectors come back
+one fp16 .npy per shard in that shard's JSONL row order (the entry script sorts by length for
+batching but writes each row back to its original index), and ids are the deterministic md5 uuids
+from the chunker — so a repeat overwrites the same points instead of duplicating them.
+
+Run it FROM PROD, not from the Qdrant box: the Qdrant instance's role cannot read
+`secondlayer-ml-data-euc1`.
+
+  QDRANT_URL=http://172.31.21.244:6333 QDRANT_API_KEY=… python3 03_upsert_amcu_vectors.py
+  python3 03_upsert_amcu_vectors.py --create-only
+"""
+import argparse
+import gzip
+import json
+import os
+import time
+
+import boto3
+import numpy as np
+import requests
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qm
+
+QDRANT = os.environ.get("QDRANT_URL", "http://127.0.0.1:6333")
+QDRANT_HOST = QDRANT.split("//")[-1].split(":")[0]
+API_KEY = os.environ.get("QDRANT_API_KEY") or None
+BUCKET = "secondlayer-ml-data-euc1"
+CHUNKS_PREFIX = "rada-npa/amcu-decisions/chunks"
+VECTORS_PREFIX = "rada-npa/amcu-decisions/vectors"
+BATCH = 1000
+
+INDEXES = [
+    ("amcu_id", "integer"),
+    ("doc_kind", "keyword"),
+    ("decision_no", "keyword"),
+    ("decision_date_ts", "integer"),
+    ("document_type", "keyword"),
+]
+
+
+def log(m):
+    print(f"[{time.strftime('%H:%M:%S')}] {m}", flush=True)
+
+
+def headers():
+    return {"api-key": API_KEY} if API_KEY else {}
+
+
+def create_collection(name):
+    r = requests.get(f"{QDRANT}/collections/{name}", headers=headers(), timeout=30)
+    if r.status_code == 200:
+        log(f"collection {name} exists")
+        return
+    # ~165K points is small enough to keep vectors in RAM — unlike the 28M-point legislation
+    # collection, which needs on_disk + binary quantization to fit.
+    body = {
+        "vectors": {"size": 1024, "distance": "Cosine"},
+        "optimizers_config": {"indexing_threshold": 0},
+    }
+    r = requests.put(f"{QDRANT}/collections/{name}", json=body, headers=headers(), timeout=60)
+    r.raise_for_status()
+    log(f"created {name}")
+    for field, schema in INDEXES:
+        rr = requests.put(f"{QDRANT}/collections/{name}/index",
+                          json={"field_name": field, "field_schema": schema},
+                          headers=headers(), timeout=60)
+        log(f"  index {field}: {rr.status_code}")
+
+
+def finalise(name):
+    r = requests.patch(f"{QDRANT}/collections/{name}",
+                       json={"optimizers_config": {"indexing_threshold": 20000}},
+                       headers=headers(), timeout=60)
+    log(f"indexing_threshold restored: {r.status_code}")
+
+
+def upsert_shard(client, name, jsonl_path, vec_path):
+    ids, payloads = [], []
+    with gzip.open(jsonl_path, "rt", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            ids.append(rec["id"])
+            payload = rec["payload"]
+            payload["text"] = rec["text"]  # so a hit renders without a second lookup
+            payloads.append(payload)
+
+    vecs = np.load(vec_path)
+    if len(vecs) != len(ids):
+        raise SystemExit(f"{jsonl_path}: {len(ids)} rows but {len(vecs)} vectors")
+
+    for i in range(0, len(ids), BATCH):
+        hi = min(i + BATCH, len(ids))
+        batch = qm.Batch(ids=ids[i:hi],
+                         vectors=vecs[i:hi].astype(np.float32).tolist(),
+                         payloads=payloads[i:hi])
+        for attempt in range(5):
+            try:
+                client.upsert(collection_name=name, points=batch, wait=False)
+                break
+            except Exception as e:
+                log(f"  retry {attempt + 1}: {str(e)[:120]}")
+                time.sleep(2 * (attempt + 1))
+        else:
+            raise SystemExit(f"upsert failed at {jsonl_path} offset {i}")
+    return len(ids)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--collection", default="amcu_bge_cls")
+    ap.add_argument("--workdir", default="/data/amcu/upsert")
+    ap.add_argument("--create-only", action="store_true")
+    a = ap.parse_args()
+
+    create_collection(a.collection)
+    if a.create_only:
+        return
+
+    os.makedirs(a.workdir, exist_ok=True)
+    state = os.path.join(a.workdir, ".upserted")
+    done = set(open(state).read().split()) if os.path.exists(state) else set()
+
+    s3 = boto3.client("s3", region_name="eu-central-1")
+    shards = sorted(o["Key"].split("/")[-1][: -len(".jsonl.gz")]
+                    for o in s3.list_objects_v2(Bucket=BUCKET, Prefix=CHUNKS_PREFIX + "/")
+                    .get("Contents", []) if o["Key"].endswith(".jsonl.gz"))
+    log(f"{len(shards)} shards, {len(done)} already loaded")
+
+    # https=False is load-bearing: qdrant-client turns TLS on the moment an api_key is passed,
+    # then fails the gRPC handshake against a plaintext port with a WRONG_VERSION_NUMBER error
+    # that reads like a certificate problem rather than a scheme mismatch.
+    client = QdrantClient(host=QDRANT_HOST, port=6333, grpc_port=6334, prefer_grpc=True,
+                          api_key=API_KEY, https=False, timeout=300)
+    total, t0 = 0, time.time()
+    for base in shards:
+        if base in done:
+            continue
+        jp = os.path.join(a.workdir, base + ".jsonl.gz")
+        vp = os.path.join(a.workdir, base + ".f16.npy")
+        s3.download_file(BUCKET, f"{CHUNKS_PREFIX}/{base}.jsonl.gz", jp)
+        s3.download_file(BUCKET, f"{VECTORS_PREFIX}/{base}.f16.npy", vp)
+        n = upsert_shard(client, a.collection, jp, vp)
+        os.remove(jp)
+        os.remove(vp)
+        total += n
+        with open(state, "a") as f:
+            f.write(base + "\n")
+        log(f"{base}: {n} points ({total:,} total, {total / (time.time() - t0):.0f}/s)")
+
+    finalise(a.collection)
+    r = requests.get(f"{QDRANT}/collections/{a.collection}", headers=headers(), timeout=60)
+    log(f"done: {total:,} points this run; collection says "
+        f"{r.json()['result'].get('points_count')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Навіщо

`opendata_amcu_decisions` уже має GIN-індекс і шукається через `search_registry` за ключовими словами. Чого воно не вміє — відповісти на «практика щодо X», коли X сформульовано інакше, ніж у тексті рішення. Ці три стадії будують семантичний шар.

Демо EVERLEGAL 13.08: обраний один корпус до демо.

## Заміряно, а не оцінено

| | |
|---|---|
| Рядків у таблиці | 6 846 |
| З придатним `body_text` | **2 600** |
| Символів тексту | 66M |
| Чанків (500/100) | **174 382** у 8 збалансованих шардах (~4.6 МБ кожен) |
| Час чанкування на проді | ~11 с |

Оцінку в 165K я перевірив, а не переніс: смоук на перших 20 рішеннях дав 212 чанків/документ, але ці 20 виявились утричі довшими за середнє — екстраполювати з них було б помилкою.

## Стадії

```
01_chunk_amcu.py         Postgres → gzipped JSONL шарди
02_launch_amcu_embed.py  один SageMaker job (reuse legislation/sagemaker/embed_entry.py)
03_upsert_amcu_vectors.py  S3 → Qdrant amcu_bge_cls
```

`embed_entry.py` виявився повністю generic — читає `{"text": …}` і пише `.f16.npy` у будь-який `--out-prefix`, тож переписувати нічого не довелося.

**Пулінг лишається CLS**, бо прод `tei-bge-m3` віддає CLS для кожного запиту користувача. Пілот законодавства 2026-07 був MEAN, і його документи опинились в іншому просторі, ніж запити, що їх шукали. Звідси суфікс `_cls` у назві колекції — щоб два простори не змішались непомітно.

**Одна `ml.g5.2xlarge`.** A10G заміряно на 307 чанків/с проти ~230 в L4, тож 174K чанків це близько десяти хвилин, ~$0.40. Механіка розщеплення флоту з НПА-прогону на цьому розмірі була б чистим накладом.

Профіль колекції свідомо інший, ніж у законодавства: 174K точок вміщаються в RAM, тож без `on_disk` векторів і без бінарної квантизації — вони існують для колекції на 28M точок, не для цієї.

## Два факти про доступи, встановлені тестом, а не читанням політики

1. **Роль прод-EC2 пише лише під `rada-npa/*`.** `PutObject` у `amcu/_probe.txt` віддав AccessDenied, тоді як ідентичний запис під `rada-npa/` пройшов. Тому дані лежать у `rada-npa/amcu-decisions/`. Чистіший префікс верхнього рівня потребує окремої inline-політики `amcu-embed-s3` за зразком наявної `rada-npa-s3` — це технічний борг, зафіксований у docstring.
2. **Та сама роль не може `iam:PassRole` для `SageMakerDPOExecutionRole`**, тож джоб запускається з local.lex (`vovkes-admin`), а не з прода.

## Стан

Джоб `amcu-bge-cls-20260812-130214` запущено, чанки в S3. Upsert у Qdrant — після завершення; підключення семантичного режиму до `search_registry` піде окремим PR, коли колекція буде на місці.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 3-stage semantic vector pipeline for АМКУ decisions to enable semantic search (“practice about X”) beyond keywords. Chunks decisions, embeds with `tei-bge-m3` (CLS), and loads vectors into Qdrant `amcu_bge_cls`.

- **New Features**
  - `01_chunk_amcu.py`: Postgres → gzipped JSONL shards; 500/100 windows, md5-stable IDs, round‑robin across 8 shards; basic metadata in payload.
  - `02_launch_amcu_embed.py`: Launches one SageMaker job reusing the legislation embed entry; CLS pooling; reads `rada-npa/amcu-decisions/chunks`, writes `.../vectors`; `ml.g5.2xlarge`.
  - `03_upsert_amcu_vectors.py`: Creates/loads Qdrant collection `amcu_bge_cls`; RAM vectors (1024, Cosine), field indexes; idempotent upserts; includes `text` in payload for rendering.

- **Migration**
  - Run in order: `01_chunk_amcu.py` → `02_launch_amcu_embed.py` → `03_upsert_amcu_vectors.py`.
  - Use S3 prefix `rada-npa/amcu-decisions/*` (current prod role only writes under `rada-npa/*`).
  - Launch SageMaker from an account that can pass `SageMakerDPOExecutionRole` (prod role cannot).
  - Upsert from prod (has S3 read); set `QDRANT_URL` and `QDRANT_API_KEY` as needed.

<sup>Written for commit 3a69b386147d5acba7ffcbf0737efb2b38c0d436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

