### PR TITLE
fix(edrsr): count_cases_by_party reported documents as cases

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -1176,12 +1176,16 @@ total_resolved_links=0 означає відсутність даних граф
         party_name: partyName,
         party_type: partyType,
         matched_name: cleanedName,
-        total_cases: counts.total,
+        // total_cases used to carry counts.total, which is a DOCUMENT count — it read as
+        // 684 "справ" for ЕВЕРЛІҐАЛ against 591 real cases, because one case yields a
+        // document at every instance it passes through.
+        total_cases: counts.distinct_cases,
+        total_documents: counts.total,
         courts_count: counts.by_court.length,
         by_court,
         time_taken_ms: Date.now() - startTime,
         method: 'fts_party_anchor',
-        note: 'Назва/роль — це FTS-прив\'язка по тексту рішення, не структурний фільтр сторони. Точне визначення ролі — після впровадження parties-таблиці (LEXAI-1760).',
+        note: 'total_cases — кількість УНІКАЛЬНИХ справ (за номером справи); total_documents — кількість документів, вона завжди більша, бо одна справа дає документи в кожній інстанції. У by_court рахуються ДОКУМЕНТИ по судах, тому сума by_court дорівнює total_documents, а не total_cases. Назва/роль — це FTS-прив\'язка по тексту рішення, не структурний фільтр сторони. Точне визначення ролі — після впровадження parties-таблиці (LEXAI-1760).',
       };
       if (counts.capped) {
         // Never let a truncated aggregate read as an exact count.

--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -173,6 +173,33 @@ describe('EdsrFtsService.countByParty', () => {
     expect(res.sample).toBeUndefined(); // sampleLimit defaults to 0
   });
 
+  it('separates distinct cases from documents (ЕВЕРЛІҐАЛ read 684 "справ" against 591 real)', async () => {
+    const svc = new EdsrFtsService();
+    const db = {
+      calls: [] as any[],
+      query: jest.fn((sql: string, params: any[]) => {
+        (db as any).calls.push({ sql, params });
+        // Every row carries the same global distinct_cases via CROSS JOIN; by_court counts
+        // DOCUMENTS, so summing it must NOT be what ends up labelled as cases.
+        return Promise.resolve({
+          rows: [
+            { candidates: 684, distinct_cases: 591, court_code: 4824, n: 400 },
+            { candidates: 684, distinct_cases: 591, court_code: 1003, n: 284 },
+          ],
+        });
+      }),
+    };
+    const res = await svc.countByParty('ЕВЕРЛІҐАЛ', undefined, db);
+
+    // documents: the sum of by_court
+    expect(res.total).toBe(684);
+    // cases: the global count(DISTINCT cause_num), never the sum — a case appears once per
+    // instance it passed through, so summing per-court counts double-counts it
+    expect(res.distinct_cases).toBe(591);
+    expect(res.distinct_cases).toBeLessThan(res.total);
+    expect(db.calls[0].sql).toContain('count(DISTINCT d.cause_num)');
+  });
+
   it('applies date/justice filters and fetches a sample when requested', async () => {
     const svc = new EdsrFtsService();
     const db = {

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -120,7 +120,19 @@ export interface EdsrFtsSearchResponse {
 }
 
 export interface PartyCaseCount {
+  /**
+   * DOCUMENT count. One case produces many documents (ухвали, рішення, постанови at each
+   * instance), so this is always >= the number of cases. Kept as `total` for callers that
+   * genuinely want documents; anything user-facing that says "справ" must use `distinct_cases`.
+   */
   total: number;
+  /**
+   * Distinct `cause_num` across the whole candidate set. Cannot be derived from `by_court` —
+   * summing per-court case counts would count a case once per instance it passed through,
+   * which is exactly how `total` came to overstate ЕВЕРЛІҐАЛ as 684 "справ" against 591 real
+   * ones. Rows with a null cause_num are excluded by count(DISTINCT ...).
+   */
+  distinct_cases: number;
   by_court: Array<{ court_code: number; count: number }>;
   sample?: Array<{ doc_id: number; cause_num: string | null; court_code: number | null; justice_kind: number | null; adjudication_date: string | null }>;
   /** True when the FTS fallback hit PARTY_COUNT_CAND_CAP — `total` is then a floor, not an exact count. */
@@ -475,6 +487,21 @@ export class EdsrFtsService {
         .map((r: any) => ({ court_code: r.court_code, count: r.n }));
       const total = countResult.rows.reduce((s: number, r: any) => s + r.n, 0);
 
+      // `total` above counts DOCUMENTS (distinct doc_id). edrsr_parties carries no cause_num,
+      // so distinct cases need the documents table — same distinction the FTS path makes, kept
+      // here so this route cannot silently report documents as "справ" if it ever goes live.
+      const casesResult = await dbPool.query(
+        `SELECT count(DISTINCT d.cause_num)::int AS distinct_cases
+           FROM edrsr_parties p JOIN edrsr_documents d ON d.doc_id = p.doc_id
+          WHERE ${whereClause.replace(/\bname_norm\b/g, 'p.name_norm')
+                              .replace(/\badj_year\b/g, 'p.adj_year')
+                              .replace(/\brole\b/g, 'p.role')
+                              .replace(/\badjudication_date\b/g, 'p.adjudication_date')
+                              .replace(/\bjustice_kind\b/g, 'p.justice_kind')}`,
+        params
+      );
+      const distinct_cases = Number(casesResult.rows[0]?.distinct_cases ?? 0);
+
       let sample: PartyCaseCount['sample'];
       if (sampleLimit > 0) {
         const safeSample = Math.min(Math.max(sampleLimit, 1), 1000);
@@ -497,9 +524,9 @@ export class EdsrFtsService {
       }
 
       logger.info('[EdsrFtsService] countByParty (fast/parties-table)', {
-        party_name: partyName, party_role: partyRole ?? 'any', years: [yFrom, yTo], total, courts: by_court.length,
+        party_name: partyName, party_role: partyRole ?? 'any', years: [yFrom, yTo], total, distinct_cases, courts: by_court.length,
       });
-      return { total, by_court, ...(sample ? { sample } : {}) };
+      return { total, distinct_cases, by_court, ...(sample ? { sample } : {}) };
     } catch (err: any) {
       logger.warn('[EdsrFtsService] countByPartyFast failed; falling back to FTS', { error: err.message, party_name: partyName });
       return null;
@@ -1146,8 +1173,14 @@ export class EdsrFtsService {
           ${docWhere}
           GROUP BY d.court_code
         )
-        SELECT c.candidates, a.court_code, a.n
+        tot AS (
+          SELECT count(DISTINCT d.cause_num)::int AS distinct_cases
+          FROM cand JOIN edrsr_documents d ON d.doc_id = cand.doc_id
+          ${docWhere}
+        )
+        SELECT c.candidates, t.distinct_cases, a.court_code, a.n
         FROM (SELECT count(*)::int AS candidates FROM cand) c
+        CROSS JOIN tot t
         LEFT JOIN agg a ON TRUE
         ORDER BY a.n DESC NULLS LAST`;
       const countResult = await dbPool.query(countSql, params);
@@ -1162,6 +1195,7 @@ export class EdsrFtsService {
         .map((r: any) => ({ court_code: r.court_code, count: r.n }));
       const total = by_court.reduce((s: number, r: any) => s + r.count, 0);
       const candidates = Number(countResult.rows[0]?.candidates ?? 0);
+      const distinct_cases = Number(countResult.rows[0]?.distinct_cases ?? 0);
       // `cand` is LIMIT-ed to the cap, so count(*) over it tops out AT the cap and this is
       // effectively `=== cap`. A party matching exactly PARTY_COUNT_CAND_CAP documents is
       // therefore flagged capped even though its count is complete. Accepted: reading
@@ -1198,11 +1232,12 @@ export class EdsrFtsService {
       logger.info('[EdsrFtsService] countByParty', {
         party_name: partyName, party_role: partyRole ?? 'any',
         filters: Object.keys(filters).filter(k => (filters as any)[k] !== undefined),
-        total, courts: by_court.length, candidates, capped,
+        total, distinct_cases, courts: by_court.length, candidates, capped,
       });
 
       return {
         total,
+        distinct_cases,
         by_court,
         ...(sample ? { sample } : {}),
         ...(capped ? { capped: true, candidate_cap: PARTY_COUNT_CAND_CAP } : {}),


### PR DESCRIPTION
## Проблема

`total_cases` ніс кількість **документів**. Одна справа дає документ у кожній інстанції, тому число завжди завищене — і саме його чат озвучує на питання «скільки у нас справ».

Знайдено під час прогону всіх 25 демо-запитів перед зустріччю з EVERLEGAL: запит №2 відповів «Загальна кількість справ: 684».

## Заміряно проти корпусу (повний скан, ~2 хв кожен)

| Написання | Документів | Унікальних справ | Судів | Інструмент казав |
|---|---|---|---|---|
| ЕВЕРЛІ**Ґ**АЛ | 684 | **591** | 177 | 684 / 177 |
| ЕВЕРЛІ**Г**АЛ | 746 | **466** | 121 | 746 / 121 |

Кількість судів була правильною в обох випадках — помилялося тільки число справ. Це завищення на **16%** для Ґ і на **60%** для Г.

## Чому сума by_court не є відповіддю

`agg` рахує `count(*)` по документах з `GROUP BY court_code`, а `total` — це сума груп. Складання груп рахує справу по разу на кожну інстанцію, яку вона пройшла. Саме тому 591 справа перетворилась на 684.

Фікс додає глобальний `count(DISTINCT d.cause_num)` по тому самому матеріалізованому набору кандидатів (ще один агрегат, без додаткового скану) і віддає обидва числа:
- `total_cases` тепер означає **справи**
- `total_documents` зберігає стару цифру для тих, кому потрібні документи

Нота інструмента прямо пояснює різницю, зокрема що **сума by_court дорівнює документам, а не справам** — щоб модель не склеїла їх назад.

## Заодно

Структурний шлях через `edrsr_parties` мав ту саму ваду (`count(DISTINCT doc_id)` — це теж документи, а cause_num у тій таблиці немає). Він мертвий, поки `edrsr_parties` порожня на проді, але виправлений, а не залишений міною на момент, коли приїде LEXAI-1760.

## Перевірка

- Регресійний тест фіксує різницю на реальних цифрах ЕВЕРЛІҐАЛ (684 документи / 591 справа) і перевіряє, що SQL містить `count(DISTINCT d.cause_num)`
- **26 тестів у наборі проходять**
- `npx tsc --noEmit` — по цих файлах чисто

## Демо-нота

Написання має значення: Ґ дає 591 справу, Г — 466, разом 912. На зустрічі варто питати обидва варіанти.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed party case counts to report unique cases instead of documents. Exposes both numbers to prevent inflated results (e.g., 684 documents vs 591 cases for "ЕВЕРЛІҐАЛ").

- **Bug Fixes**
  - Added global count(DISTINCT d.cause_num) over the candidate set; service returns distinct cases and the tool maps them to `total_cases` with `total_documents` kept separately.
  - Clarified the note: `by_court` sums to documents, not cases.
  - Corrected the `edrsr_parties` path to compute distinct cases via join with documents, so it won’t miscount when `LEXAI-1760` lands.
  - Added a regression test covering the 684/591 split and asserting `count(DISTINCT d.cause_num)` in SQL.

- **Migration**
  - Use `total_cases` for case counts. Use `total_documents` if you need document counts.
  - Do not sum `by_court` for case totals; it represents documents.

<sup>Written for commit e324b20378d22dfdcc9be5dea2b9b6dac50b1280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

