### PR TITLE
fix(edrsr): missing comma between CTEs broke count_cases_by_party

### DIFF
--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -197,7 +197,14 @@ describe('EdsrFtsService.countByParty', () => {
     // instance it passed through, so summing per-court counts double-counts it
     expect(res.distinct_cases).toBe(591);
     expect(res.distinct_cases).toBeLessThan(res.total);
-    expect(db.calls[0].sql).toContain('count(DISTINCT d.cause_num)');
+    const sql = db.calls[0].sql;
+    expect(sql).toContain('count(DISTINCT d.cause_num)');
+    // Structural guard: a mocked db never executes the SQL, so a missing comma between CTEs
+    // passes every behavioural assertion and only fails in production. That exact bug shipped
+    // once — 'syntax error at or near "tot"'.
+    expect(sql).toMatch(/\)\s*,\s*tot AS \(/);
+    // No CTE may follow another without a comma: `) name AS (` is always malformed here.
+    expect(sql).not.toMatch(/\)\s*\n\s*[a-z_]+ AS \(/);
   });
 
   it('applies date/justice filters and fetches a sample when requested', async () => {

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -1172,7 +1172,7 @@ export class EdsrFtsService {
           FROM cand JOIN edrsr_documents d ON d.doc_id = cand.doc_id
           ${docWhere}
           GROUP BY d.court_code
-        )
+        ),
         tot AS (
           SELECT count(DISTINCT d.cause_num)::int AS distinct_cases
           FROM cand JOIN edrsr_documents d ON d.doc_id = cand.doc_id


### PR DESCRIPTION
## Що сталося

PR #2260 додав CTE `tot` для підрахунку унікальних справ, але **не поставив кому** після `agg`. Кожен виклик `count_cases_by_party` падає з:

```
Error: Помилка підрахунку справ: Party count failed: syntax error at or near "tot"
```

Інструмент повертає помилку на проді з моменту того деплою. Це один із демо-запитів (№2 — «скільки справ у ЕВЕРЛІҐАЛ»), тож без цього фіксу він завтра впаде.

Знайдено не тестом, а тим, що я пішов перевіряти попередній фікс проти ground truth: відповідь прийшла за 186 мс замість 4.4 с і з `isError: true`.

## Чому тести це пропустили

Юніт-тести `countByParty` мокають базу — SQL-рядок ніколи не потрапляє в Postgres, тому зламаний список CTE проходить усі поведінкові перевірки й падає лише в проді.

Додано **структурний guard**, який вимагає кому між CTE. Я не повірив йому на око, а перевірив: тимчасово повернув зламаний SQL — `1 failed, 25 passed`; повернув виправлений — `26 passed`. Guard справді ловить саме цю помилку.

## Перевірка

Виправлений запит виконано **проти корпусу прода до цього коміту** — повертає рівно виміряний ground truth:

```
 candidates | distinct_cases | total_documents | courts
------------+----------------+-----------------+--------
        684 |            591 |             684 |    177
Time: 3932 ms
```

591 справа / 684 документи / 177 судів — збігається з прямим підрахунком по корпусу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SQL syntax error in `EdsrFtsService.countByParty` by adding a missing comma between CTEs, restoring party case counts in production. Adds a test guard to prevent this class of error.

- **Bug Fixes**
  - Inserted the missing comma between the `agg` and `tot` CTEs to fix "syntax error at or near 'tot'".
  - Added a structural test that asserts CTEs are comma-separated, so malformed CTE lists fail in tests.

<sup>Written for commit 42fa0820d757a2943a66ed44af98b7a2e8bd3584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

