### PR TITLE
fix(spending): contracts were invisible, and the error said "timeout"

### DIFF
--- a/mcp_backend/src/api/__tests__/spending-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/spending-tools.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression tests for search_public_spending.
+ *
+ * The bug these exist for: the SELECT listed `parent_id` for every table, but that column links
+ * a child document back to its contract and so does not exist on spending_contracts. Every
+ * contracts query threw, the per-table catch swallowed it, and the tool reported an empty result
+ * with a note blaming a timeout — so contracts were invisible even under the default doc_type
+ * 'all', while 368 rows matched the queried window on prod.
+ */
+
+import { SpendingTools } from '../tools/spending-tools.js';
+
+jest.mock('../../utils/logger.js', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+const parse = (r: any) => JSON.parse(r.content[0].text);
+
+describe('search_public_spending', () => {
+  it('does not select parent_id from the contracts table', async () => {
+    const db = { calls: [] as any[], query: jest.fn((sql: string) => { (db as any).calls.push(sql); return Promise.resolve({ rows: [] }); }) };
+    const tools = new SpendingTools(db);
+
+    await tools.executeTool('search_public_spending', { doc_type: 'contracts', date_from: '2024-01-01' });
+
+    const sql = db.calls[0];
+    expect(sql).toContain('FROM spending_contracts');
+    expect(sql).toContain('NULL::bigint AS parent_id');
+    // the bare column would throw: `column "parent_id" does not exist`
+    expect(sql).not.toMatch(/contractors,\s*parent_id/);
+  });
+
+  it('still selects the real parent_id for child-document tables', async () => {
+    const db = { calls: [] as any[], query: jest.fn((sql: string) => { (db as any).calls.push(sql); return Promise.resolve({ rows: [] }); }) };
+    const tools = new SpendingTools(db);
+
+    await tools.executeTool('search_public_spending', { doc_type: 'acts', date_from: '2024-01-01' });
+
+    expect(db.calls[0]).toContain('FROM spending_acts');
+    expect(db.calls[0]).toMatch(/contractors,\s*parent_id/);
+    expect(db.calls[0]).not.toContain('NULL::bigint');
+  });
+
+  it('reports a failing table instead of passing it off as "no results"', async () => {
+    const db = {
+      query: jest.fn(() => Promise.reject(new Error('column "parent_id" does not exist'))),
+    };
+    const tools = new SpendingTools(db);
+
+    const out = parse(await tools.executeTool('search_public_spending', { doc_type: 'contracts', date_from: '2024-01-01' }));
+
+    expect(out.total).toBe(0);
+    expect(out.failed_tables).toHaveLength(1);
+    expect(out.failed_tables[0].table).toBe('spending_contracts');
+    // the old note blamed a timeout and hid a hard SQL error
+    expect(out.note).toContain('помилкою');
+    expect(out.note).not.toContain('надто широким');
+  });
+
+  it('flags a partial result when one table of an "all" query fails', async () => {
+    let n = 0;
+    const db = {
+      query: jest.fn(() => {
+        n++;
+        if (n === 1) return Promise.resolve({ rows: [{ id: 1, sign_date: '2025-01-01', amount: 100 }] });
+        return Promise.reject(new Error('boom'));
+      }),
+    };
+    const tools = new SpendingTools(db);
+
+    const out = parse(await tools.executeTool('search_public_spending', { date_from: '2024-01-01' }));
+
+    expect(out.returned).toBe(1);
+    expect(out.partial).toBe(true);
+    expect(out.failed_tables.length).toBeGreaterThan(0);
+  });
+});

--- a/mcp_backend/src/api/tools/spending-tools.ts
+++ b/mcp_backend/src/api/tools/spending-tools.ts
@@ -15,6 +15,12 @@ const TABLE_MAP: Record<string, string> = {
   contracts: 'spending_contracts',
 };
 
+// `parent_id` links a child document back to its contract, so the contracts table itself does
+// not have the column. Selecting it unconditionally made EVERY contracts query throw
+// (`column "parent_id" does not exist`), and the per-table catch turned that into a silent
+// zero — contracts were invisible even under the default doc_type 'all'.
+const TABLES_WITHOUT_PARENT_ID = new Set(['spending_contracts']);
+
 const DOC_TYPE_LABELS: Record<string, string> = {
   acts: 'Акт виконаних робіт',
   addendums: 'Додаткова угода',
@@ -131,13 +137,17 @@ export class SpendingTools extends BaseToolHandler {
         : Object.entries(TABLE_MAP);
 
     const allResults: any[] = [];
+    const tableErrors: Array<{ table: string; error: string }> = [];
     const QUERY_TIMEOUT_MS = 15000;
 
     for (const [dtype, tableName] of tables) {
       try {
+        const parentIdCol = TABLES_WITHOUT_PARENT_ID.has(tableName)
+          ? 'NULL::bigint AS parent_id'
+          : 'parent_id';
         const sql = `SELECT id, edrpou, document_number, document_date, sign_date,
           amount, currency, pdv_include, pdv_amount,
-          contractors, parent_id
+          contractors, ${parentIdCol}
           FROM ${tableName}
           WHERE ${whereClause}
           ORDER BY sign_date DESC NULLS LAST
@@ -158,6 +168,9 @@ export class SpendingTools extends BaseToolHandler {
           });
         }
       } catch (err: any) {
+        // Record it as well as logging: swallowing this silently is what let a broken
+        // contracts query read as "no results" for as long as it did.
+        tableErrors.push({ table: tableName, error: String(err.message).slice(0, 200) });
         logger.warn(`[SpendingTools] Error querying ${tableName}`, { error: err.message });
       }
     }
@@ -177,7 +190,10 @@ export class SpendingTools extends BaseToolHandler {
         total: 0,
         returned: 0,
         results: [],
-        note: 'Результатів не знайдено. Можливо, запит був надто широким і перевищив timeout. Спробуйте уточнити параметри (вказати edrpou, звузити діапазон дат).',
+        ...(tableErrors.length ? { failed_tables: tableErrors } : {}),
+        note: tableErrors.length
+          ? `Запит до ${tableErrors.length} таблиць(і) завершився помилкою — це НЕ означає, що даних немає. Див. failed_tables.`
+          : 'Результатів не знайдено. Можливо, запит був надто широким і перевищив timeout. Спробуйте уточнити параметри (вказати edrpou, звузити діапазон дат).',
       }, null, 2));
     }
 
@@ -185,6 +201,7 @@ export class SpendingTools extends BaseToolHandler {
       query: { edrpou, contractor_name, contractor_edrpou, date_from, date_to, min_amount, max_amount, doc_type },
       total: allResults.length,
       returned: trimmed.length,
+      ...(tableErrors.length ? { failed_tables: tableErrors, partial: true } : {}),
       results: trimmed,
     }, null, 2));
   }


### PR DESCRIPTION
## Проблема

`search_public_spending` вибирав `parent_id` з усіх чотирьох таблиць. Але це поле пов'язує дочірній документ із його договором — і в самій таблиці `spending_contracts` його **немає**.

Кожен запит по договорах падав з `column "parent_id" does not exist`, per-table `catch` це ковтав, а інструмент віддавав порожній результат із нотою, що запит «надто широкий або перевищив timeout».

Тобто **договори не поверталися ніколи** — ні за прямим `doc_type: "contracts"`, ні під дефолтним `all`. На проді у вікні, яке інструмент показав порожнім, лежать **368 договорів**.

```
spending_acts       parent_id: t
spending_addendums  parent_id: t
spending_peny       parent_id: t
spending_contracts  parent_id: f   ← 
```

Знайдено під час прогону всіх 54 інструментів через **підключений MCP-клієнт**, а не через бекенд напряму. Ззовні це виглядало рівно як порожній датасет — відрізнити можна було лише перевіркою самої таблиці.

## Зміни

1. Для таблиць без цього поля вибирається `NULL::bigint AS parent_id` — форма результату лишається однаковою для всіх чотирьох типів документів.
2. **Помилки таблиць більше не ковтаються**: повертаються у `failed_tables`, а якщо частина таблиць усе ж дала рядки — ще й `partial: true`. Нота при нулі результатів більше не звинувачує timeout, коли причиною була жорстка SQL-помилка.

Друга зміна важливіша за першу: саме мовчазне ковтання дозволило зламаному запиту стільки часу читатися як «даних немає».

## Перевірка

Виправлений запит виконано проти прода **до коміту** — повертає реальні договори (НБУ, ТОВ «Укрком»).

4 регресійні тести: обидві форми колонки (`NULL::bigint` для договорів, справжній `parent_id` для дочірніх) і обидва шляхи помилок (повний провал і часткова видача).

`npx tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invisible contracts in `search_public_spending` by not selecting a missing `parent_id` from `spending_contracts`. Queries now return contracts, and real SQL errors are surfaced instead of a misleading “timeout” note.

- **Bug Fixes**
  - Use `NULL::bigint AS parent_id` for tables without that column (e.g., `spending_contracts`) to keep a uniform result shape.
  - Stop swallowing per-table errors; return `failed_tables` and set `partial: true` when some tables succeed.
  - Update the zero-results note to reflect table errors instead of blaming a broad query or timeout.

<sup>Written for commit 1bc5567571b9e34b0747cc323683cae5ac2f6885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

