### PR TITLE
fix(edrsr): get_court_decision returned the same text twice

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -20,6 +20,9 @@ import type { IEmbeddingPort } from '../../domain/ports/index.js';
 import { LegalPatternStore } from '../../services/legal-pattern-store.js';
 import type { CitationGraphService } from '../../services/citation-graph-service.js';
 import { SectionType } from '../../types/index.js';
+
+/** Preview kept on get_court_decision when the same text is already returned as sections. */
+const FULL_TEXT_PREVIEW_CHARS = 2000;
 import { logger } from '../../utils/logger.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import { generateCaseNumberVariations, extractSnippets, resolveCauseNumber, edrsrPool } from '../tool-utils.js';
@@ -518,7 +521,23 @@ total_resolved_links=0 означає відсутність даних граф
       url,
       depth,
       sections: sections.slice(0, depth),
-      full_text: fullText || undefined,
+      // When sections were extracted they already contain this text, so shipping full_text too
+      // doubled the payload for zero information: doc 117473073 came back as 282K characters —
+      // 139.7K of sections plus 139.6K of the same text again — and blew an MCP client's token
+      // limit outright. Only ~0.4% of decisions exceed 60K chars, but the ones that do are
+      // exactly the long cassation rulings worth opening.
+      //
+      // Safe to trim: chat never forwards full_text to the model (chat-result-compactor:
+      // "Never sends full_text to LLM — extracts key sections instead") and reads it only as a
+      // fallback when sections are missing. So keep it whole when there are no sections, and
+      // reduce it to a preview when there are. Raw text remains available via load_full_texts.
+      ...(sections.length > 0 && fullText.length > FULL_TEXT_PREVIEW_CHARS
+        ? {
+            full_text_preview: fullText.slice(0, FULL_TEXT_PREVIEW_CHARS),
+            full_text_truncated: true,
+            full_text_hint: 'Повний текст не дублюється тут, бо він уже розібраний у sections. Потрібен суцільний текст — використайте load_full_texts.',
+          }
+        : { full_text: fullText || undefined }),
       full_text_length: fullText.length,
     };
 


### PR DESCRIPTION
## Проблема

Відповідь несла і `sections`, і `full_text` — а це **той самий текст**: секціонатор ріже full_text на ФАКТИ / МОТИВУВАННЯ / РІШЕННЯ, він його не стискає.

Документ 117473073 повернувся як **282 218 символів**:

```
sections    139 766 chars
full_text   139 663 chars   ← той самий текст ще раз
```

Це перевищує ліміт токенів MCP-клієнта, тобто виклик **падає з помилкою**, а не просто віддає багато.

Знайдено під час прогону всіх 54 інструментів через підключений MCP-клієнт.

## Наскільки часто

Заміряно на партиції 2024 (200K рішень): p50 = **5 174** символи, p90 = 18 075, p99 = 46 328, максимум 475 284. Понад 60K мають лише **0.40%**.

Але саме ці 0.4% — довгі касаційні постанови, які й варто відкривати. **117473073 — показова справа для завтрашнього демо.**

## Чому обрізати безпечно

Не за припущенням, а за кодом: `chat-result-compactor` прямо каже

> «Never sends full_text to LLM — extracts key sections (FACTS, REASONING, DECISION) instead»

і читає `full_text` **лише як фолбек**, коли секцій немає.

Тому:
- секцій немає → `full_text` віддається повністю, як і раніше
- секції є → замість дубля повертається `full_text_preview` (2K), `full_text_truncated: true`, `full_text_length` і підказка на `load_full_texts` для суцільного тексту

## Залишковий ризик

Це прибирає дубль (282K → ~142K), але для найдовших рішень payload усе одно великий. Повне вирішення — пагінація секцій; воно не входить у цей PR і не робиться за ніч до демо.

## ⚠ Окремо

`src/api/__tests__` **червоний на main**: 16 suites / 154 тести падають ДО цієї зміни і ті самі 16/154 падають ПІСЛЯ — тобто цей PR не додає жодного. Перевірено прогоном на чистому `origin/main` зі стешнутою зміною. Це заслуговує окремого тікета.

`npx tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicating court decision text in `get_court_decision` by returning a 2K preview instead of `full_text` when `sections` are present, cutting large payloads and preventing token-limit failures.

- **Bug Fixes**
  - If `sections` exist and `full_text` > 2000 chars, return `full_text_preview`, `full_text_truncated: true`, `full_text_length`, and a `full_text_hint` to use `load_full_texts`.
  - If no `sections`, keep returning full `full_text` as before.
  - Adds `FULL_TEXT_PREVIEW_CHARS = 2000`; trims worst-case responses roughly in half on long decisions.

<sup>Written for commit a150a111449f0571f16751709a0a1e7d5dcfb518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

