### PR TITLE
fix(edrsr): bound section text so get_court_decision stays transportable

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -23,6 +23,18 @@ import { SectionType } from '../../types/index.js';
 
 /** Preview kept on get_court_decision when the same text is already returned as sections. */
 const FULL_TEXT_PREVIEW_CHARS = 2000;
+
+/**
+ * Per-section ceiling for get_court_decision.
+ *
+ * The sectionizer does not always segment: on doc 117473073 it returned ONE section of type
+ * HEADER holding all 138,139 characters, so `depth` could not bound anything — asking for a
+ * single section still returned the whole decision. Even after dropping the duplicated
+ * full_text the response was 143K characters and still exceeded an MCP client's token limit.
+ * Bounding each section keeps the response transportable whatever the sectionizer returns;
+ * continuous text is available through load_full_texts.
+ */
+const SECTION_TEXT_CAP = 40000;
 import { logger } from '../../utils/logger.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import { generateCaseNumberVariations, extractSnippets, resolveCauseNumber, edrsrPool } from '../tool-utils.js';
@@ -505,10 +517,17 @@ total_resolved_links=0 означає відсутність даних граф
       ? extractedSections
           .filter((s: any) => s && typeof s.text === 'string')
           .slice(0, 10)
-          .map((s: any) => ({
-            type: s.type,
-            text: s.text,
-          }))
+          .map((s: any) => {
+            const text: string = s.text;
+            return text.length > SECTION_TEXT_CAP
+              ? {
+                  type: s.type,
+                  text: text.slice(0, SECTION_TEXT_CAP),
+                  text_truncated: true,
+                  text_length: text.length,
+                }
+              : { type: s.type, text };
+          })
       : [];
 
     const payload: any = {


### PR DESCRIPTION
## Продовження #2263

Той PR прибрав дубль і зменшив документ 117473073 з 282K до **143K** символів — але цього все одно **не вистачило**: виклик через MCP-клієнт далі падає з перевищенням ліміту токенів.

## Що залишилось

Перевірка відповіді показала справжню причину:

```
sections: 1
  [0] type='HEADER'  text=138 139 chars
full_text_preview: 2 000   ← фікс #2263 спрацював
full_text_length: 139 663
```

**Секціонатор не сегментував рішення взагалі** — повернув ОДНУ секцію типу `HEADER` з усім текстом. Наслідок, який легко пропустити: параметр `depth` при цьому нічого не обмежує. Я запитав `depth: 1` і отримав усе рішення, бо все рішення і було першою секцією.

## Зміна

Кожна секція обмежується 40K символів із `text_truncated` і `text_length`, щоб викликач бачив, що саме зрізано. Суцільний текст — через `load_full_texts`.

Це робить відповідь транспортабельною **незалежно від того, що поверне секціонатор**, замість того щоб покладатися на якісну сегментацію.

## Окремо

Те, що секціонатор віддає ціле рішення як `HEADER` — **окремий дефект**, вартий свого тікета. Цей PR прибирає наслідок для транспорту, але не лікує сегментацію.

`src/api/__tests__` лишається на своєму доміграційному рівні 16 suites / 154 тести (червоні на main до і після).

`npx tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps each section in get_court_decision at 40K characters to keep responses transportable regardless of sectionizer output. Previously, the sectionizer sometimes returned a single `HEADER` with the entire decision (~138k), so `depth` did not limit output and MCP clients exceeded token limits; now oversized sections are truncated with clear metadata.

- Adds `SECTION_TEXT_CAP = 40000`; when a section exceeds the cap, returns `text` sliced to 40K plus `text_truncated: true` and `text_length`.
- Keeps the 2,000‑char `full_text` preview; continuous text remains available via `load_full_texts`.
- No breaking changes: untruncated sections are unchanged; extra fields appear only when truncation occurs.

<sup>Written for commit a8e5efb055a5c8227d7dd5df0b02773a2942401a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

