### PR TITLE
fix(mcp): /sse hid 23 of 54 tools it could already execute

### DIFF
--- a/mcp_backend/src/api/__tests__/mcp-sse-tools-whitelist.test.ts
+++ b/mcp_backend/src/api/__tests__/mcp-sse-tools-whitelist.test.ts
@@ -87,5 +87,10 @@ describe('MCPSSEServer tools/list curated whitelist', () => {
     for (const n of names) {
       expect(V2_TOOL_NAMES.has(n)).toBe(true);
     }
+
+    // tools/list must read the merged list, not the local-only one: /sse can execute
+    // rada_*/openreyestr_* (handleToolCall proxies via toolRegistry.executeTool) but used to
+    // advertise only local tools, hiding 23 of the 54 curated tools from a ChatGPT client.
+    expect(fakeRegistry.getAllToolDefinitions).toHaveBeenCalled();
   });
 });

--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -70,10 +70,35 @@ export class MCPSSEServer {
    * Get all available tools in MCP format
    */
   getAllTools(): MCPToolDefinition[] {
-    const allTools = this.toolRegistry.getLocalToolDefinitions();
+    return this.toMcpFormat(this.toolRegistry.getLocalToolDefinitions());
+  }
 
-    // Convert to MCP format
-    return allTools.map((tool: any) => ({
+  /**
+   * Local tools PLUS the proxied rada_* / openreyestr_* definitions.
+   *
+   * /sse could always EXECUTE prefixed tools — handleToolCall goes through
+   * toolRegistry.executeTool, which proxies them — but it advertised only the local ones, so a
+   * ChatGPT client never saw 23 of the 54 curated tools: the whole ЄДР surface (companies,
+   * beneficiaries, debtors, Prozorro, РНБО, ФОП, tax/ЄСВ debt) and every parliament tool.
+   * A client cannot call what it cannot see, so the endpoint looked like it lacked the
+   * registries entirely.
+   *
+   * Falls back to the local list if the remote fetch fails, matching how the Streamable-HTTP
+   * transport handles the same call (mcp-sse-routes.ts).
+   */
+  private async getAllToolsIncludingRemote(): Promise<MCPToolDefinition[]> {
+    try {
+      return this.toMcpFormat(await this.toolRegistry.getAllToolDefinitions());
+    } catch (error: any) {
+      logger.warn('[MCP SSE] Remote tool definitions unavailable; advertising local only', {
+        error: error?.message,
+      });
+      return this.getAllTools();
+    }
+  }
+
+  private toMcpFormat(tools: any[]): MCPToolDefinition[] {
+    return tools.map((tool: any) => ({
       name: tool.name,
       description: tool.description || '',
       inputSchema: tool.inputSchema || {
@@ -318,7 +343,7 @@ export class MCPSSEServer {
    * Handle tools/list request
    */
   private async handleToolsList(res: Response, request: MCPRequest): Promise<void> {
-    const allTools = this.getAllTools();
+    const allTools = await this.getAllToolsIncludingRemote();
 
     // Advertise the curated v2 tool set — same whitelist as /api/v2/mcp — instead of
     // a blind slice(0, N). The previous slice kept only the first 15 tools by registration


### PR DESCRIPTION
## Проблема

Транспорт `/sse` — той, яким історично підключається ChatGPT — рекламував **лише локальні інструменти**. `handleToolsList` читав `getLocalToolDefinitions()`, тож клієнт ніколи не бачив **23 з 54** кураторських назв:

- усі 19 `openreyestr_*` — компанії, бенефіціари, боржники, виконавчі провадження, банкрутство, Prozorro, санкції РНБО, АРМА, НАЗК, ФОП, податковий борг і ЄСВ
- усі 4 `rada_*` — законопроєкти, висновки ГНЕУ, депутати, голосування

Тобто саме блок «державні реєстри» з сьогоднішнього демо.

## Найцікавіше

Ендпоінт **завжди міг їх виконувати**: `handleToolCall` іде через `toolRegistry.executeTool`, який проксює префіксовані виклики в rada/openreyestr. Локальною була тільки **реклама**. А клієнт не може викликати те, чого не бачить — тож `/sse` виглядав так, ніби реєстрів там немає взагалі.

## Зміна

`handleToolsList` і так був async, тож це просто читання зі злитого джерела з фолбеком на локальний список, якщо віддалений запит впав — рівно та сама форма, яку вже використовує Streamable-HTTP транспорт (`mcp-sse-routes.ts`).

`getAllTools()` зберігає свій синхронний локальний контракт для discovery-роуту й наявних викликів.

## Навіщо саме зараз

`/api/v2/mcp` уже віддає всі 54 і саме ним користується Claude Code. Але ChatGPT-конектори історично беруть `/sse`. Цей фікс прибирає питання «а який транспорт обере клієнт» — обидва тепер повні.

## Перевірка

- api-набір без змін: **19 suites / 291 тест**
- регресійний whitelist-тест тепер стверджує, що `tools/list` читає **злиті** визначення, а не локальні

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advertises the merged tool list over `/sse` so clients see all 54 curated tools. Previously `/sse tools/list` showed only local tools, hiding 23 `rada_*`/`openreyestr_*` tools that the endpoint could already execute; now it lists local + proxied tools with a safe fallback.

- `handleToolsList` now reads merged definitions (local + remote) with a fallback to local and a warning log; matches Streamable-HTTP behavior.
- `getAllTools()` keeps its synchronous, local-only contract; new helper converts to MCP format.
- Adds a whitelist regression test asserting `/sse tools/list` uses merged definitions.
- No API shape changes; on remote failure, `/sse` still advertises local tools. No migration required.

<sup>Written for commit 50077f98f5ad6595a872928c4e952a8447f3631c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

