### PR TITLE
fix(edrsr): every court date reached the model a day early

### DIFF
--- a/mcp_backend/src/adapters/edrsr-local-adapter.ts
+++ b/mcp_backend/src/adapters/edrsr-local-adapter.ts
@@ -5,6 +5,7 @@ import type { IEmbeddingPort, ICachePort } from '../domain/ports/index.js';
 import { requestContext } from '../utils/openai-client.js';
 import type { CostTracker } from '../services/cost-tracker.js';
 import { SectionType } from '../types/index.js';
+import { formatCourtDate } from '../api/tool-utils.js';
 import {
   type ZakonOnlineDomainName,
   type DomainConfig,
@@ -311,7 +312,7 @@ export class EdsrLocalAdapter {
           const chamber = doc.chamber || this.extractChamberFromText(doc.full_text || doc.resolution || null);
 
           const title = doc.title || doc.name || doc.cause_num || doc.caption || undefined;
-          const date = doc.adjudication_date || doc.date || doc.published_at || undefined;
+          const date = formatCourtDate(doc.adjudication_date || doc.date || doc.published_at);
           const caseNumber = doc.cause_num || doc.case_number || doc.metadata?.cause_num || undefined;
 
           return {
@@ -378,7 +379,7 @@ export class EdsrLocalAdapter {
         zakononline_id: String(doc.doc_id),
         type: 'court_decision',
         title: doc.title || doc.cause_num || undefined,
-        date: doc.adjudication_date || doc.date || undefined,
+        date: formatCourtDate(doc.adjudication_date || doc.date),
         case_number: doc.cause_num || undefined,
         court: (doc.court || doc.court_name) ? String(doc.court || doc.court_name) : (doc.court_code != null ? String(doc.court_code) : undefined),
         chamber: chamber,

--- a/mcp_backend/src/api/__tests__/court-date-timezone.test.ts
+++ b/mcp_backend/src/api/__tests__/court-date-timezone.test.ts
@@ -1,0 +1,47 @@
+import { formatCourtDate } from '../tool-utils';
+
+/**
+ * Regression for the 907/665/18 report (2026-08-13): every date in the answer was
+ * one day early. `adjudication_date` is a timestamptz at Kyiv midnight, so the
+ * постанова of 23.04.2026 is the instant 2026-04-22T21:00:00Z; serialised as an
+ * ISO string it reached the model as "2026-04-22…" and got reported as 22.04.2026.
+ *
+ * The dates below are the instants stored in edrsr_documents for real documents
+ * of that case, paired with the date printed on the document itself.
+ */
+describe('formatCourtDate', () => {
+  it.each([
+    ['2026-04-22T21:00:00.000Z', '2026-04-23', 'постанова про визнання банкрутом (summer, +03)'],
+    ['2018-11-19T22:00:00.000Z', '2018-11-20', 'ухвала про прийняття заяви (winter, +02)'],
+    ['2021-12-21T22:00:00.000Z', '2021-12-22', 'постанова ЗАГС у справі ФК «Монтале»'],
+    ['2023-06-21T21:00:00.000Z', '2023-06-22', 'постанова ЗАГС (Тищенко/ТКСЗ)'],
+    ['2024-08-21T21:00:00.000Z', '2024-08-22', 'постанова ЗАГС (ГУ ДПС)'],
+    ['2025-04-28T21:00:00.000Z', '2025-04-29', 'постанова ЗАГС (Фінактив)'],
+  ])('%s → %s (%s)', (stored, expected) => {
+    expect(formatCourtDate(stored)).toBe(expected);
+    expect(formatCourtDate(new Date(stored))).toBe(expected);
+  });
+
+  it('keeps date-only values exactly as they are', () => {
+    expect(formatCourtDate('2026-04-23')).toBe('2026-04-23');
+  });
+
+  it('holds across the DST switch in both directions', () => {
+    // Kyiv moves to +03 on the last Sunday of March, back to +02 in late October.
+    expect(formatCourtDate('2025-03-29T22:00:00.000Z')).toBe('2025-03-30'); // +02 → local midnight
+    expect(formatCourtDate('2025-03-30T21:00:00.000Z')).toBe('2025-03-31'); // +03 → local midnight
+    expect(formatCourtDate('2025-10-25T21:00:00.000Z')).toBe('2025-10-26');
+    expect(formatCourtDate('2025-10-26T22:00:00.000Z')).toBe('2025-10-27');
+  });
+
+  it('returns undefined for empty values rather than an epoch date', () => {
+    expect(formatCourtDate(null)).toBeUndefined();
+    expect(formatCourtDate(undefined)).toBeUndefined();
+    expect(formatCourtDate('')).toBeUndefined();
+    expect(formatCourtDate(new Date('nonsense'))).toBeUndefined();
+  });
+
+  it('passes unparseable input through untouched instead of inventing a date', () => {
+    expect(formatCourtDate('не встановлено')).toBe('не встановлено');
+  });
+});

--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -13,6 +13,38 @@ import axios from 'axios';
 
 // ========================= Pure Functions =========================
 
+const KYIV_DATE = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: 'Europe/Kyiv',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+/**
+ * Render an EDRSR date as the calendar date the court actually stamped on the act.
+ *
+ * `adjudication_date` is a timestamptz holding Kyiv midnight, so a decision of
+ * 23.04.2026 is the instant 2026-04-22T21:00:00Z. Serialised straight to JSON it
+ * reaches the model as that UTC string, and every consumer reading the UTC
+ * calendar day is one day early — a report on 907/665/18 dated all six cited
+ * decisions to the day before the documents themselves (2026-08-13).
+ *
+ * Emitting `YYYY-MM-DD` in Kyiv removes the ambiguity instead of moving it:
+ * there is no time-of-day left to reinterpret downstream. Values that are
+ * already date-only pass through untouched, and anything unparseable is left
+ * exactly as it came rather than silently becoming a wrong date.
+ */
+export function formatCourtDate(value: unknown): string | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : KYIV_DATE.format(value);
+  }
+  const raw = String(value);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? raw : KYIV_DATE.format(parsed);
+}
+
 /**
  * Parse JSON from LLM response, stripping markdown fences if present.
  * Handles: ```json {...} ```, ```{...}```, or raw JSON.
@@ -592,7 +624,7 @@ export async function countAllResults(
     cause_num: r.cause_num,
     judge: r.judge,
     court_code: r.court_code,
-    adjudication_date: r.adjudication_date,
+    adjudication_date: formatCourtDate(r.adjudication_date),
     url: `https://reyestr.court.gov.ua/Review/${r.doc_id}`,
   }));
 

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -37,7 +37,7 @@ const FULL_TEXT_PREVIEW_CHARS = 2000;
 const SECTION_TEXT_CAP = 40000;
 import { logger } from '../../utils/logger.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
-import { generateCaseNumberVariations, extractSnippets, resolveCauseNumber, edrsrPool } from '../tool-utils.js';
+import { generateCaseNumberVariations, extractSnippets, resolveCauseNumber, edrsrPool, formatCourtDate } from '../tool-utils.js';
 
 /**
  * Resolve requested judgment-form names ("Рішення", "постанови") to the
@@ -588,7 +588,7 @@ total_resolved_links=0 означає відсутність даних граф
       judge: row.judge || undefined,
       court_name: courtName || undefined,
       judgment_form: judgmentForm || undefined,
-      adjudication_date: row.adjudication_date || undefined,
+      adjudication_date: formatCourtDate(row.adjudication_date),
       url,
       depth,
       sections: sections.slice(0, depth),
@@ -939,7 +939,7 @@ total_resolved_links=0 означає відсутність даних граф
       instance: classifyInstance(row),
       court: row.court_name || null,
       judge: row.judge,
-      date: row.adjudication_date,
+      date: formatCourtDate(row.adjudication_date),
       url: `https://reyestr.court.gov.ua/Review/${row.doc_id}`,
       ...(includeFullText && row.full_text ? { full_text: row.full_text } : {}),
     }));
@@ -1029,8 +1029,8 @@ total_resolved_links=0 означає відсутність даних граф
       summary: {
         scope: 'вся справа',
         date_range: {
-          from: firstDate ? firstDate.toISOString() : undefined,
-          to: lastDate ? lastDate.toISOString() : undefined,
+          from: formatCourtDate(firstDate),
+          to: formatCourtDate(lastDate),
         },
         instances: populationInstances,
         document_types: {
@@ -1260,7 +1260,7 @@ total_resolved_links=0 означає відсутність даних граф
         doc_id: row.doc_id,
         case_number: row.cause_num || undefined,
         judge: row.judge || undefined,
-        adjudication_date: row.adjudication_date || undefined,
+        adjudication_date: formatCourtDate(row.adjudication_date),
         url,
         full_text_length: fullText.length,
         excerpt_source: source,

--- a/mcp_backend/src/api/tools/edrsr-extended-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-extended-tools.ts
@@ -14,6 +14,7 @@ import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handle
 import { logger } from '../../utils/logger.js';
 import { extractDispositiveFromText } from '../../utils/dispositive.js';
 import { cleanEdrsrTextSql } from '../../services/edrsr-fts-service.js';
+import { formatCourtDate } from '../tool-utils.js';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -318,7 +319,7 @@ export class EdsrExtendedTools extends BaseToolHandler {
     return rows.map((row) => ({
       doc_id: row.doc_id,
       cause_num: row.cause_num,
-      adjudication_date: row.adjudication_date,
+      adjudication_date: formatCourtDate(row.adjudication_date),
       judge: row.judge,
       court_code: row.court_code,
       court_name: courtName,

--- a/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
@@ -14,6 +14,7 @@ import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handle
 import { logger } from '../../utils/logger.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsResult } from '../../services/edrsr-fts-service.js';
 import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
+import { formatCourtDate } from '../tool-utils.js';
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
@@ -233,7 +234,7 @@ snippet з FTS, найкращий chunk з Qdrant). Dedup по doc_id (Qdrant �
           court_code: r.court_code,
           justice_kind: r.justice_kind,
           judgment_code: r.judgment_code,
-          adjudication_date: r.adjudication_date,
+          adjudication_date: formatCourtDate(r.adjudication_date),
         },
       };
       byDocId.set(docId, hit);
@@ -295,7 +296,7 @@ snippet з FTS, найкращий chunk з Qdrant). Dedup по doc_id (Qdrant �
             justice_kind: v.metadata?.justice_kind,
             judgment_code: v.metadata?.judgment_code,
             category_code: v.metadata?.category_code,
-            adjudication_date: v.metadata?.adjudication_date,
+            adjudication_date: formatCourtDate(v.metadata?.adjudication_date),
           },
         });
       }
@@ -357,7 +358,7 @@ snippet з FTS, найкращий chunk з Qdrant). Dedup по doc_id (Qdrant �
       judgment_code: h.metadata.judgment_code ?? null,
       judgment_form: h.metadata.judgment_code ? judgmentMap.get(h.metadata.judgment_code) || null : null,
       category_code: h.metadata.category_code ?? null,
-      adjudication_date: h.metadata.adjudication_date || null,
+      adjudication_date: formatCourtDate(h.metadata.adjudication_date) || null,
       rrf_score: Number(h.rrf_score.toFixed(6)),
       fts_position: h.fts_position,
       fts_rank: h.fts_rank,
@@ -391,11 +392,7 @@ snippet з FTS, найкращий chunk з Qdrant). Dedup по doc_id (Qdrant �
           justice_kind: row.justice_kind ?? undefined,
           judgment_code: row.judgment_code ?? undefined,
           category_code: row.category_code ?? undefined,
-          adjudication_date: row.adjudication_date
-            ? (typeof row.adjudication_date === 'string'
-                ? row.adjudication_date
-                : row.adjudication_date.toISOString())
-            : undefined,
+          adjudication_date: formatCourtDate(row.adjudication_date),
         });
       }
     } catch (err: any) {

--- a/mcp_backend/src/api/tools/edrsr-search-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-search-tools.ts
@@ -11,6 +11,7 @@
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import { logger } from '../../utils/logger.js';
 import { EDRSR_METADATA_SEARCH_ORDER } from '../../services/search-ranking-config.js';
+import { formatCourtDate } from '../tool-utils.js';
 
 export class EdsrSearchTools extends BaseToolHandler {
   constructor(private db: any) {
@@ -431,7 +432,7 @@ export class EdsrSearchTools extends BaseToolHandler {
       justice_kind_name: justiceMap.get(row.justice_kind) || null,
       judgment_code: row.judgment_code,
       judgment_form: judgmentMap.get(row.judgment_code) || null,
-      adjudication_date: row.adjudication_date,
+      adjudication_date: formatCourtDate(row.adjudication_date),
       receipt_date: row.receipt_date,
       doc_url: row.doc_url,
       external_url: `https://reyestr.court.gov.ua/Review/${row.doc_id}`,

--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -21,6 +21,7 @@ import type { QueryReformulator } from '../../services/query-reformulator.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsSearchResponse } from '../../services/edrsr-fts-service.js';
 import { selectFtsTerms, sanitizeFtsToken, buildPrefixTsquery, isStatusVocabToken } from '../../services/edrsr-fts-service.js';
 import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
+import { formatCourtDate } from '../tool-utils.js';
 
 const DEFAULT_RRF_K = 60;
 const DEFAULT_OVERSAMPLE = 3;
@@ -892,7 +893,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       const enriched = await this.enrichResults(topResults.map(r => ({
         doc_id: r.doc_id, cause_num: r.metadata.cause_num, judge: r.metadata.judge,
         court_code: r.metadata.court_code, justice_kind: r.metadata.justice_kind,
-        judgment_code: r.metadata.judgment_code, adjudication_date: r.metadata.adjudication_date,
+        judgment_code: r.metadata.judgment_code, adjudication_date: formatCourtDate(r.metadata.adjudication_date),
         rank: r.score,
       })));
 
@@ -949,7 +950,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
         doc_id: docId, rrf_score: 1 / (k + rank),
         fts_rank: Number(r.rank) || 0, fts_position: rank, fts_headline: r.headline || null,
         qdrant_score: null, qdrant_position: null, qdrant_best_chunk_text: null, qdrant_best_chunk_index: null,
-        metadata: { cause_num: r.cause_num, judge: r.judge, court_code: r.court_code, justice_kind: r.justice_kind, judgment_code: r.judgment_code, adjudication_date: r.adjudication_date },
+        metadata: { cause_num: r.cause_num, judge: r.judge, court_code: r.court_code, justice_kind: r.justice_kind, judgment_code: r.judgment_code, adjudication_date: formatCourtDate(r.adjudication_date) },
       });
     });
 
@@ -1014,7 +1015,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       court_code: row.court_code, court_name: courtsMap.get(row.court_code) || null,
       justice_kind: row.justice_kind, justice_kind_name: justiceMap.get(row.justice_kind) || null,
       judgment_code: row.judgment_code, judgment_form: judgmentMap.get(row.judgment_code) || null,
-      adjudication_date: row.adjudication_date, receipt_date: row.receipt_date,
+      adjudication_date: formatCourtDate(row.adjudication_date), receipt_date: formatCourtDate(row.receipt_date),
       doc_url: row.doc_url, external_url: `https://reyestr.court.gov.ua/Review/${row.doc_id}`,
       ...(row.full_text ? { full_text: row.full_text } : {}),
       ...(row.headline ? { headline: row.headline } : {}),
@@ -1084,7 +1085,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       court_code: h.metadata.court_code ?? null, court_name: h.metadata.court_code ? courtsMap.get(h.metadata.court_code) || null : null,
       justice_kind: h.metadata.justice_kind ?? null, justice_kind_name: h.metadata.justice_kind ? justiceMap.get(h.metadata.justice_kind) || null : null,
       judgment_code: h.metadata.judgment_code ?? null, judgment_form: h.metadata.judgment_code ? judgmentMap.get(h.metadata.judgment_code) || null : null,
-      adjudication_date: h.metadata.adjudication_date || null,
+      adjudication_date: formatCourtDate(h.metadata.adjudication_date) || null,
       rrf_score: Number(h.rrf_score.toFixed(6)),
       fts_position: h.fts_position, fts_rank: h.fts_rank, fts_headline: h.fts_headline,
       qdrant_position: h.qdrant_position, qdrant_score: h.qdrant_score !== null ? Number(h.qdrant_score.toFixed(6)) : null,

--- a/mcp_backend/src/api/tools/legal-advice-tools.ts
+++ b/mcp_backend/src/api/tools/legal-advice-tools.ts
@@ -22,7 +22,7 @@ import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { CourtDecisionHTMLParser, extractSearchTermsWithAI } from '../../utils/html-parser.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
-import { countAllResults, buildSupremeCourtWhereFilter, mapProcedureCodeToJusticeKind, extractSnippets } from '../tool-utils.js';
+import { countAllResults, buildSupremeCourtWhereFilter, mapProcedureCodeToJusticeKind, extractSnippets, formatCourtDate } from '../tool-utils.js';
 
 /** Max cases to enrich with precedent status per search (cost/latency guard) */
 const MAX_SHEPARDIZATION_BATCH = 15;
@@ -78,7 +78,7 @@ export class LegalAdviceTools extends BaseToolHandler {
       judge: r.judge,
       court_code: r.court_code,
       justice_kind: r.justice_kind,
-      adjudication_date: r.adjudication_date,
+      adjudication_date: formatCourtDate(r.adjudication_date),
       url: `https://reyestr.court.gov.ua/Review/${r.doc_id}`,
       ...(r.headline ? { headline: r.headline } : {}),
       ...(r.rank != null ? { rank: r.rank } : {}),
@@ -439,7 +439,7 @@ export class LegalAdviceTools extends BaseToolHandler {
             doc_id: sourceCase.doc_id,
             judge: sourceCase.judge,
             court_code: sourceCase.court_code,
-            adjudication_date: sourceCase.adjudication_date,
+            adjudication_date: formatCourtDate(sourceCase.adjudication_date),
             url: `https://reyestr.court.gov.ua/Review/${sourceCase.doc_id}`,
             category_code: sourceCase.category_code,
             justice_kind: sourceCase.justice_kind,

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -34,6 +34,7 @@ import {
   searchWithInstanceCascade,
   mapProcedureCodeToJusticeKind,
   safeParseJsonFromToolResult,
+  formatCourtDate,
 } from '../tool-utils.js';
 
 /**
@@ -470,7 +471,7 @@ export class ProceduralTools extends BaseToolHandler {
     const results = rows.slice(0, limit).map((r) => ({
       doc_id: r.doc_id,
       court_code: r.court_code,
-      date: r.adjudication_date,
+      date: formatCourtDate(r.adjudication_date),
       case_number: r.cause_num,
       url: `https://reyestr.court.gov.ua/Review/${r.doc_id}`,
       section_focus: sectionFocus,
@@ -785,7 +786,7 @@ export class ProceduralTools extends BaseToolHandler {
           semanticHits.push({
             doc_id: h.doc_id,
             court_code: h.metadata.court_code,
-            date: h.metadata.adjudication_date,
+            date: formatCourtDate(h.metadata.adjudication_date),
             case_number: h.metadata.cause_num,
             fragment: (h.text || '').slice(0, 900),
           });
@@ -1091,7 +1092,7 @@ export class ProceduralTools extends BaseToolHandler {
           results.push({
             doc_id: h.doc_id,
             court_code: h.metadata.court_code,
-            date: h.metadata.adjudication_date,
+            date: formatCourtDate(h.metadata.adjudication_date),
             case_number: h.metadata.cause_num,
             snippet: (h.text || '').slice(0, 600) + ((h.text || '').length > 600 ? '…' : ''),
             score: typeof h.score === 'number' ? Number(h.score.toFixed(4)) : undefined,


### PR DESCRIPTION
## Що не так

`adjudication_date` — це `timestamptz` з київською північчю. Постанова від 23.04.2026 у справі 907/665/18 зберігається як інстант `2026-04-22T21:00:00Z`. Інструменти віддавали його в JSON як є, і будь-хто, хто читає календарний день у UTC — модель у тому числі — втрачав добу.

У звіті по 907/665/18 (`chat-6f5253de`) всі шість цитованих дат виявились на день раніше за самі документи:

| У відповіді | У документі | doc_id |
|---|---|---|
| 07.12.2021 | **08.12.2021** | 102051154 |
| 21.12.2021 | **22.12.2021** | 102407731 |
| 21.06.2023 | **22.06.2023** | 113117362 |
| 21.08.2024 | **22.08.2024** | 121642599 |
| 28.04.2025 | **29.04.2025** | 127157013 |
| 22.04.2026 | **23.04.2026** | 136199626 |

Показово, що дати, які модель брала **з тексту** рішень (ухвали 08.09.2021, 21.02.2023, 31.01.2024, 08.08.2024), лишились правильними — зсув був рівно там, де дата йшла з метаданих.

Це не одна ручка: те саме поле годує `search_court_decisions`, гібридний і уніфікований пошук, процесуальні інструменти, підбір практики та локальний адаптер ЄДРСР.

## Що змінено

Один хелпер `formatCourtDate` у `tool-utils.ts`, застосований у 19 місцях, де дата йде назовні. Дати покидають бекенд як `YYYY-MM-DD` за Києвом — часу доби, який можна переінтерпретувати нижче за течією, більше не лишається. Значення, що вже є датою, проходять без змін; те, що не парситься, повертається як прийшло, а не перетворюється на хибну дату; порожнє стає `undefined`, а не 1970 роком.

## Перевірка

- `Europe/Kyiv` перевірено в самому прод-образі (node v20.20.2): `2026-04-22T21:00:00.000Z` → `2026-04-23`, `2018-11-19T22:00:00.000Z` → `2018-11-20`.
- Новий `court-date-timezone.test.ts` — на реальних інстантах з `edrsr_documents` проти дат, надрукованих у самих документах, плюс обидва переходи на літній/зимовий час.
- 7 сюїт, які торкаються дат (`case-chain-window`, `edrsr-hybrid`, `edrsr-unified-search`, `edrsr-extended`, `due-diligence`, `pro-contra-holding` + нова): **100/100**.
- `tsc --noEmit` — лише три звичні помилки оверлея core.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes one-day shifts in court dates by emitting Kyiv-local `YYYY-MM-DD` instead of UTC timestamps. Previously `adjudication_date` left as a UTC instant (Kyiv midnight), which consumers read as the prior UTC day; now all exposed court dates are date-only strings, eliminating reinterpretation. Side effects: date-only inputs pass through, empty inputs become `undefined`, and unparseable strings pass through untouched.

**Review and rollout**
- Centralize date rendering in `formatCourtDate` in `mcp_backend/src/api/tool-utils.ts` (Kyiv timezone, DST-safe).
- Apply `formatCourtDate` across adapters and tools: local adapter, `edrsr` search/hybrid/unified/extended, court-decision, procedural, legal-advice, and `countAllResults`.
- Add `court-date-timezone.test.ts` covering real instants and DST switches; verify `Europe/Kyiv` is available in the runtime image.
- Migration: If a client expects timestamps, update it to accept `YYYY-MM-DD` or derive timestamps from the string.

<sup>Written for commit 071553ecc623d1d2cd2e00cf6aea101302a993fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

