### PR TITLE
feat(edrsr): harvest fulltexts on a schedule, and stop trusting a hardcoded IP list

### DIFF
--- a/.github/workflows/cron-edrsr-fulltext.yml
+++ b/.github/workflows/cron-edrsr-fulltext.yml
@@ -1,0 +1,99 @@
+##############################################################################
+# EDRSR Daily Fulltext Harvest: od.reyestr.court.gov.ua → prod PostgreSQL
+# - Companion to cron-edrsr-sync.yml, which imports METADATA only. Until this
+#   workflow existed the texts were fetched by hand: the last manual run was
+#   2026-07-15, so by 2026-08-13 the corpus had metadata for 680K documents it
+#   had no text for — July at 32% coverage, August at 0%, while every earlier
+#   month sat at 97-99%.
+# - Runs on the prod self-hosted runner, 02:30 UTC — after the 01:00 UTC
+#   metadata sync, so the documents it harvests are already in edrsr_documents.
+# - Trailing window, not "yesterday": a decision's metadata and its text can
+#   both land days late, and the harvester only fetches what is missing, so an
+#   overlapping window is cheap and closes gaps the previous runs left.
+##############################################################################
+name: 'Cron: EDRSR Fulltext Harvest'
+
+on:
+  schedule:
+    # 02:30 UTC = 05:30 Kyiv, 90 min after the metadata sync starts
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+    inputs:
+      days_back:
+        description: 'How many days back to harvest (default 10)'
+        required: false
+        default: '10'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: edrsr-fulltext
+  cancel-in-progress: false
+
+jobs:
+  harvest:
+    name: Harvest missing fulltexts
+    runs-on: [self-hosted, prod-deploy]
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure the egress IP is configured
+        run: |
+          # Secondary private IPs are added with `ip addr add`, which does not
+          # survive a reboot. Best-effort: re-add the ones the ENI already owns.
+          # If none can egress the harvester exits non-zero below — loudly, rather
+          # than reporting a successful run that fetched nothing.
+          TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" \
+            -H "X-aws-ec2-metadata-token-ttl-seconds: 120")
+          META="http://169.254.169.254/latest/meta-data"
+          MAC=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" "$META/network/interfaces/macs/" | head -1)
+          PRIMARY=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" "$META/local-ipv4")
+          # Only private IPs that actually have an EIP behind them are worth
+          # configuring — the rest have no route out and would just slow the probe.
+          for pub in $(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+              "$META/network/interfaces/macs/${MAC}public-ipv4s"); do
+            priv=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+              "$META/network/interfaces/macs/${MAC}ipv4-associations/$pub")
+            [ -z "$priv" ] && continue
+            [ "$priv" = "$PRIMARY" ] && continue
+            ip -4 addr show dev ens5 | grep -q "inet $priv/" || sudo -n ip addr add "$priv/20" dev ens5 || true
+            echo "  egress $priv -> $pub"
+          done
+          ip -4 -o addr show dev ens5 | awk '{print "  configured:", $4}'
+
+      - name: Harvest
+        run: |
+          DAYS="${{ inputs.days_back || '10' }}"
+          FROM=$(date -u -d "-${DAYS} days" +%Y-%m-%d)
+          TO=$(date -u -d "+1 day" +%Y-%m-%d)
+          echo "Harvesting $FROM .. $TO (exclusive)"
+          python3 scripts/edrsr/download-fulltext-prod.py \
+            --from "$FROM" --to "$TO" \
+            --rtf-dir "/home/ubuntu/edrsr-rtf-daily"
+
+      - name: Coverage report
+        if: always()
+        run: |
+          docker exec secondlayer-postgres-prod psql -U secondlayer -d secondlayer_prod -A -F'|' -c "
+            SELECT d.adjudication_date::date AS day,
+                   count(*) AS docs,
+                   count(f.doc_id) AS with_text,
+                   round(100.0 * count(f.doc_id) / count(*), 1) AS pct
+            FROM edrsr_documents d
+            LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+            WHERE d.adjudication_date >= current_date - interval '10 days'
+              AND d.adjudication_date < current_date + interval '1 day'
+            GROUP BY 1 ORDER BY 1;"
+
+      - name: Prune harvested RTFs older than 3 days
+        if: always()
+        run: |
+          # The RTFs are a download scratch area — the text lives in Postgres
+          # once imported. Keeping them lets a re-run skip re-downloading, but
+          # they accumulate at ~30GB per million documents.
+          find /home/ubuntu/edrsr-rtf-daily -type f -mtime +3 -delete 2>/dev/null || true
+          du -sh /home/ubuntu/edrsr-rtf-daily 2>/dev/null || true

--- a/scripts/edrsr/download-fulltext-prod.py
+++ b/scripts/edrsr/download-fulltext-prod.py
@@ -28,28 +28,53 @@ from collections import defaultdict
 from multiprocessing import Pool
 
 # ── Config ──
-# Prod ENI secondary private IPs, each with its own EIP. Verified 2026-07-15:
-# every one egresses via a distinct public IP and gets HTTP 200 from reyestr.
-# The primary IP (172.31.29.20 → 18.192.189.254) is deliberately excluded — it
-# carries prod's own traffic (TURN/STUN, outbound API) and must not risk a
-# reyestr-side throttle.
-SOURCE_IPS = [
-    "172.31.21.47",     # 52.57.240.221
-    "172.31.22.206",    # 3.74.236.42
-    "172.31.27.31",     # 35.157.236.160
-    "172.31.28.109",    # 63.177.198.82
-    "172.31.31.40",     # 18.198.163.194
-    "172.31.21.255",    # 3.122.149.159
-    "172.31.19.142",    # 3.125.14.33
-    "172.31.19.20",     # 3.65.44.169
-    "172.31.17.145",    # 63.185.68.100
-    "172.31.16.240",    # 3.64.220.201
-    "172.31.21.126",    # 63.184.96.255
-    "172.31.21.214",    # 18.185.195.46
-    "172.31.27.133",    # 3.74.66.255
-    "172.31.22.179",    # 3.68.255.49
-]
+# Egress pool: prod ENI secondary private IPs, each needing its own EIP for a
+# distinct outbound address. This list used to be hardcoded from the 2026-07-15
+# run; by 2026-08-13 thirteen of those EIPs had been released, so every address
+# in it was dead while the file still claimed they were "verified". The pool is
+# now discovered at run time and probed before use — a stale list must not be
+# able to look like a working one again.
+#
+# The primary IP (172.31.29.20 → 18.192.189.254) stays out of the pool by
+# default: it carries prod's own traffic (TURN/STUN, outbound API, on-demand
+# load_full_texts) and must not risk a reyestr-side throttle. --allow-primary
+# overrides that when it is the only address available.
+PRIMARY_IP = "172.31.29.20"
+EGRESS_IFACE = "ens5"
+PROBE_URL = "https://od.reyestr.court.gov.ua/"
 THREADS_PER_IP = 5
+
+
+def discover_source_ips(explicit=None, allow_primary=False, iface=EGRESS_IFACE):
+    """Return the IPv4 addresses on `iface` that can actually reach reyestr.
+
+    Every candidate is probed; the ones that fail are reported, never dropped in
+    silence. An IP configured on the interface without an EIP behind it has no
+    route out, so a probe is the only honest test of the pool's real size.
+    """
+    if explicit:
+        candidates = [ip.strip() for ip in explicit.split(',') if ip.strip()]
+    else:
+        out = subprocess.run(
+            ['ip', '-4', '-o', 'addr', 'show', 'dev', iface],
+            capture_output=True, text=True,
+        ).stdout
+        candidates = re.findall(r'inet (\d+\.\d+\.\d+\.\d+)/', out)
+        if not allow_primary:
+            candidates = [ip for ip in candidates if ip != PRIMARY_IP]
+
+    live, dead = [], []
+    for ip in candidates:
+        probe = subprocess.run(
+            ['curl', '-s', '-o', '/dev/null', '-w', '%{http_code}',
+             '--interface', ip, '--max-time', '15', PROBE_URL],
+            capture_output=True, text=True,
+        )
+        (live if probe.stdout.strip().startswith('2') else dead).append(ip)
+
+    if dead:
+        print(f"  ! unusable egress IPs (no EIP / no route): {', '.join(dead)}", flush=True)
+    return live, dead
 
 RTF_DIR = Path("/home/ubuntu/edrsr-rtf")  # overridden by --rtf-dir
 CONTAINER = "secondlayer-postgres-prod"
@@ -245,13 +270,13 @@ async def download_one(session, doc_id, url, stats, semaphore, source_ip):
 BATCH_SIZE = 50000  # Process in batches to avoid OOM on 8M+ items
 
 
-async def download_batch(batch_items, stats, threads_per_ip):
+async def download_batch(batch_items, stats, threads_per_ip, source_ips):
     """Download one batch of items across all IPs."""
     import aiohttp
 
     ip_items = defaultdict(list)
     for i, item in enumerate(batch_items):
-        ip = SOURCE_IPS[i % len(SOURCE_IPS)]
+        ip = source_ips[i % len(source_ips)]
         ip_items[ip].append(item)
 
     async def ip_worker(source_ip, ip_docs):
@@ -271,7 +296,7 @@ async def download_batch(batch_items, stats, threads_per_ip):
     await asyncio.gather(*[ip_worker(ip, docs) for ip, docs in ip_items.items()])
 
 
-async def download_all(items, threads_per_ip):
+async def download_all(items, threads_per_ip, source_ips):
     stats = DownloadStats(len(items))
     total_batches = (len(items) + BATCH_SIZE - 1) // BATCH_SIZE
 
@@ -288,7 +313,7 @@ async def download_all(items, threads_per_ip):
         start = batch_idx * BATCH_SIZE
         batch = items[start:start + BATCH_SIZE]
         print(f"\n  --- Batch {batch_idx + 1}/{total_batches} ({len(batch)} items) ---", flush=True)
-        await download_batch(batch, stats, threads_per_ip)
+        await download_batch(batch, stats, threads_per_ip, source_ips)
 
     prog_task.cancel()
     print(f"\n  Download complete: {stats.report()}", flush=True)
@@ -401,6 +426,10 @@ def main():
     parser.add_argument('--batch', type=int, default=2000, help='DB import batch size')
     parser.add_argument('--workers', type=int, default=max(1, (os.cpu_count() or 2) - 1),
                         help='CPU workers for RTF→text parsing (default: cores-1)')
+    parser.add_argument('--ips', default=None,
+                        help='Comma-separated egress IPs to use instead of discovering them')
+    parser.add_argument('--allow-primary', action='store_true',
+                        help=f"Permit the primary IP ({PRIMARY_IP}) in the pool — it carries prod's own traffic")
     args = parser.parse_args()
 
     for d in (args.date_from, args.date_to):
@@ -413,14 +442,28 @@ def main():
         Path(f"/home/ubuntu/edrsr-rtf-{args.date_from}_{args.date_to}")
 
     threads_per_ip = args.threads
-    total_workers = len(SOURCE_IPS) * threads_per_ip
+
+    source_ips = []
+    if not args.skip_download:
+        print("[0/4] Probing egress pool...", flush=True)
+        source_ips, _dead = discover_source_ips(args.ips, args.allow_primary)
+        if not source_ips:
+            print(
+                "ERROR: no usable egress IP. Secondary private IPs need an EIP each "
+                "(aws ec2 allocate-address + associate-address, then `ip addr add <priv>/20 dev ens5`). "
+                "Re-run with --allow-primary to use the prod primary IP instead.",
+                file=sys.stderr, flush=True,
+            )
+            return 1
+    total_workers = len(source_ips) * threads_per_ip
 
     RTF_DIR.mkdir(parents=True, exist_ok=True)
 
     print("=" * 60, flush=True)
     print(f"  ЄДРСР Fulltext — PROD multi-IP download", flush=True)
     print(f"  Range: {args.date_from} .. {args.date_to} (adjudication_date)", flush=True)
-    print(f"  IPs: {len(SOURCE_IPS)} × {threads_per_ip} threads = {total_workers} workers", flush=True)
+    print(f"  IPs: {len(source_ips)} × {threads_per_ip} threads = {total_workers} workers", flush=True)
+    print(f"  Egress: {', '.join(source_ips) or 'n/a (import only)'}", flush=True)
     print(f"  RTF parse workers: {args.workers}", flush=True)
     print(f"  RTF dir: {RTF_DIR}", flush=True)
     print("=" * 60, flush=True)
@@ -454,8 +497,8 @@ def main():
         print(f"  To download: {len(items)}", flush=True)
 
         if items:
-            print(f"\n[2/4] Downloading {len(items)} RTFs ({len(SOURCE_IPS)} IPs × {threads_per_ip} threads)...", flush=True)
-            asyncio.run(download_all(items, threads_per_ip))
+            print(f"\n[2/4] Downloading {len(items)} RTFs ({len(source_ips)} IPs × {threads_per_ip} threads)...", flush=True)
+            asyncio.run(download_all(items, threads_per_ip, source_ips))
         else:
             print("[2/4] All files already downloaded", flush=True)
     else:
@@ -467,4 +510,6 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    # Exit code matters: this runs unattended from cron, where a silent 0 on
+    # "no usable egress IP" would look exactly like a successful harvest.
+    sys.exit(main() or 0)


### PR DESCRIPTION
## Що знайшлось

Денний крон `cron-edrsr-sync.yml` тягне з data.gov.ua **лише метадані**. Повні тексти качав окремий ручний скрипт, і останній ручний запуск був **15.07.2026**. За місяць корпус розійшовся: метадані є, текстів нема.

| Місяць 2026 | Документів | З текстом | % |
|---|---|---|---|
| січень | 682 445 | 677 827 | 99.3 |
| ... | | | 96.8–98.6 |
| червень | 851 193 | 823 913 | 96.8 |
| **липень** | 784 106 | 250 809 | **32.0** |
| **серпень** | 179 827 | 0 | **0.0** |

Обрив по днях: 12.07 ще повний, 13.07 частковий (6 559 з 44 754), з 14.07 — нуль. Разом **680 684** документи без тексту (з них 38 419 взагалі без `doc_url`).

Саме через це звіт по справі 907/665/18 не міг дочитати хвіст: дві найновіші постанови апеляції (`138182705`, `138182709`) є в метаданих, а тексту в базі не існує.

## Друга причина — протухлий список IP

`download-fulltext-prod.py` мав захардкоджені 14 вторинних IP з коментарем «Verified 2026-07-15: every one egresses via a distinct public IP and gets HTTP 200». На 13.08 з них живий **один**: 13 EIP були звільнені після липневого прогону, а `ip addr add` не переживає перезавантаження. Файл при цьому продовжував стверджувати, що пул робочий.

## Що зроблено

- **`cron-edrsr-fulltext.yml`** — щодня о 02:30 UTC на прод-раннері, ковзне вікно 10 днів (текст може приїхати на кілька днів пізніше за метадані; качається лише відсутнє, тож перекриття дешеве). Крок перед запуском повертає на `ens5` ті приватні IP, у яких ще є EIP.
- **Пул виявляється в рантаймі й пробується перед роботою.** Непридатні адреси друкуються в лог, а прогін без жодного робочого IP завершується ненульовим кодом — мовчазний «успіх», який нічого не зібрав, більше неможливий. З'явились `--ips` і `--allow-primary`.

## Перевірка на проді

- Смоук на 19.07.2026: 16/16 завантажено та імпортовано, `adj_year` / `tsv` / `justice_kind` заповнені, тексти справжні, день став 100%.
- Крок «ensure egress IP» прогнаний дослівно: знаходить `172.31.19.20 -> 18.158.172.197`, ідемпотентний.
- Догін бэклогу (13.07 → 14.08, 642 248 документів) запущений на проді, ~101 док/с на одному IP.

## Що лишається вручну

13 звільнених EIP не повертаються самі — на це в прод-ролі немає прав, і моя AWS-сесія протермінована. З одним IP щоденний обсяг (~35 тис.) береться за ~6 хвилин, тож для регулярної роботи пулу вистачає; більше адрес потрібно лише для великих історичних догонів.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Schedules daily EDRSR fulltext harvesting and replaces the stale hardcoded egress IP list with runtime discovery and probing, preventing silent “successful” runs that fetch nothing. Previously, texts were fetched manually and the script trusted a fixed list of secondary IPs; now the workflow runs nightly, discovers usable IPs, and exits non‑zero if none are available.

- Adds `/.github/workflows/cron-edrsr-fulltext.yml`: runs 02:30 UTC over a trailing 10‑day window, re-adds secondary private IPs that still have EIPs using EC2 metadata, downloads only missing texts to `/home/ubuntu/edrsr-rtf-daily`, emits a coverage report from `secondlayer-postgres-prod`, and prunes RTFs older than 3 days.
- Updates `scripts/edrsr/download-fulltext-prod.py`: removes the hardcoded IP list in favor of runtime discovery and reachability probing; logs dead IPs; refuses the primary IP by default with `--allow-primary` override; adds `--ips` for manual pools; distributes work across live IPs; exits non‑zero when no egress IP is usable.

Required operations
- Ensure at least one secondary private IP on `ens5` has an associated EIP; otherwise the nightly run will fail non‑zero. The workflow can re-add configured private IPs but cannot allocate/associate EIPs. If urgently needed, run manually with `--allow-primary` or an explicit `--ips` list.

<sup>Written for commit 6d77d900338afff4e5df140a6f670dc6b4615fee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

